### PR TITLE
feat: refresh UI and add stone unit

### DIFF
--- a/app/bmi/page.tsx
+++ b/app/bmi/page.tsx
@@ -3,12 +3,13 @@ import { useMemo, useState } from 'react';
 import CalcShell from '../components/CalcShell';
 import BmiGauge from '../components/BmiGauge';
 
-type Unit = 'metric' | 'us';
+type Unit = 'metric' | 'us' | 'uk';
 
 // acceptable human ranges (adjust if you want)
 const LIMITS = {
   metric: { cm: { min: 90, max: 250 }, kg: { min: 25, max: 250 } },
-  us:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, lb: { min: 60, max: 550 } }
+  us:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, lb: { min: 60, max: 550 } },
+  uk:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, st: { min: 4, max: 50 }, lb: { min: 0, max: 13 } }
 };
 
 // parse, strip leading zeros, clamp
@@ -26,12 +27,17 @@ export default function BMIPage() {
   const [cmRaw, setCmRaw] = useState('175');
   const [kgRaw, setKgRaw] = useState('75');
 
-  // us inputs
+  // us / uk height inputs
   const [ftRaw, setFtRaw] = useState('5');
   const [inRaw, setInRaw] = useState('9');
+
+  // us weight
   const [lbRaw, setLbRaw] = useState('165');
 
-  const { cm, kg, ft, inch, lb, error } = useMemo(() => {
+  // uk weight
+  const [stRaw, setStRaw] = useState('11');
+  const [stLbRaw, setStLbRaw] = useState('0');
+  const { cm, kg, ft, inch, lb, st, error } = useMemo(() => {
     if (unit === 'metric') {
       const sH = sanitize(cmRaw, LIMITS.metric.cm.min, LIMITS.metric.cm.max);
       const sW = sanitize(kgRaw, LIMITS.metric.kg.min, LIMITS.metric.kg.max);
@@ -41,8 +47,8 @@ export default function BMIPage() {
           : (Number.isNaN(sH.n) || Number.isNaN(sW.n))
           ? 'Invalid number.'
           : '';
-      return { cm: sH.n, kg: sW.n, ft: NaN, inch: NaN, lb: NaN, error };
-    } else {
+      return { cm: sH.n, kg: sW.n, ft: NaN, inch: NaN, lb: NaN, st: NaN, error };
+    } else if (unit === 'us') {
       const sF = sanitize(ftRaw, LIMITS.us.ft.min, LIMITS.us.ft.max);
       const sI = sanitize(inRaw, LIMITS.us.in.min, LIMITS.us.in.max);
       const sL = sanitize(lbRaw, LIMITS.us.lb.min, LIMITS.us.lb.max);
@@ -52,9 +58,21 @@ export default function BMIPage() {
           : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sL.n))
           ? 'Invalid number.'
           : '';
-      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sL.n, error };
+      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sL.n, st: NaN, error };
+    } else {
+      const sF = sanitize(ftRaw, LIMITS.uk.ft.min, LIMITS.uk.ft.max);
+      const sI = sanitize(inRaw, LIMITS.uk.in.min, LIMITS.uk.in.max);
+      const sS = sanitize(stRaw, LIMITS.uk.st.min, LIMITS.uk.st.max);
+      const sP = sanitize(stLbRaw, LIMITS.uk.lb.min, LIMITS.uk.lb.max);
+      const error =
+        !sF.raw || !sI.raw || !sS.raw || !sP.raw
+          ? 'Enter height and weight.'
+          : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sS.n) || Number.isNaN(sP.n))
+          ? 'Invalid number.'
+          : '';
+      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sP.n, st: sS.n, error };
     }
-  }, [unit, cmRaw, kgRaw, ftRaw, inRaw, lbRaw]);
+  }, [unit, cmRaw, kgRaw, ftRaw, inRaw, lbRaw, stRaw, stLbRaw]);
 
   const bmi = useMemo(() => {
     if (error) return NaN;
@@ -63,9 +81,10 @@ export default function BMIPage() {
       return +(kg / (h * h)).toFixed(1);
     } else {
       const totalIn = ft * 12 + inch;
-      return +((lb / (totalIn * totalIn)) * 703).toFixed(1);
+      const weightLb = unit === 'us' ? lb : st * 14 + lb;
+      return +((weightLb / (totalIn * totalIn)) * 703).toFixed(1);
     }
-  }, [unit, cm, kg, ft, inch, lb, error]);
+  }, [unit, cm, kg, ft, inch, lb, st, error]);
 
   const cat = useMemo(() => {
     if (!Number.isFinite(bmi)) return '';
@@ -78,7 +97,7 @@ export default function BMIPage() {
   return (
     <CalcShell
       title="BMI Calculator"
-      subtitle="Calculate your Body Mass Index. Units: Metric or US."
+      subtitle="Calculate your Body Mass Index. Units: Metric, US or St/lb."
       result={
         <>
           <div className="kpi"><span>BMI</span><span>{Number.isFinite(bmi) ? bmi : '—'}</span></div>
@@ -94,6 +113,7 @@ export default function BMIPage() {
         <div className="segment" role="tablist" aria-label="Units">
           <button className={unit==='metric'?'active':''} onClick={()=>setUnit('metric')} role="tab" aria-selected={unit==='metric'}>Metric</button>
           <button className={unit==='us'?'active':''} onClick={()=>setUnit('us')} role="tab" aria-selected={unit==='us'}>US Units</button>
+          <button className={unit==='uk'?'active':''} onClick={()=>setUnit('uk')} role="tab" aria-selected={unit==='uk'}>St/lb</button>
         </div>
       </div>
 
@@ -125,7 +145,7 @@ export default function BMIPage() {
           </div>
           {error && <div className="help-error">{error}</div>}
         </div>
-      ) : (
+      ) : unit === 'us' ? (
         <div className="grid grid-2">
           <div>
             <label>Height</label>
@@ -137,6 +157,24 @@ export default function BMIPage() {
           <div>
             <label>Weight (lb)</label>
             <input className={`input ${error ? 'error' : ''}`} inputMode="decimal" type="text" value={lbRaw} maxLength={4} onChange={(e)=>setLbRaw(e.target.value)} />
+          </div>
+          {error && <div className="help-error">{error}</div>}
+        </div>
+      ) : (
+        <div className="grid grid-2">
+          <div>
+            <label>Height</label>
+            <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:12}}>
+              <input className={`input ${error ? 'error' : ''}`} inputMode="numeric" type="text" value={ftRaw} maxLength={1} onChange={(e)=>setFtRaw(e.target.value)} placeholder="ft" />
+              <input className={`input ${error ? 'error' : ''}`} inputMode="numeric" type="text" value={inRaw} maxLength={2} onChange={(e)=>setInRaw(e.target.value)} placeholder="in" />
+            </div>
+          </div>
+          <div>
+            <label>Weight</label>
+            <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:12}}>
+              <input className={`input ${error ? 'error' : ''}`} inputMode="numeric" type="text" value={stRaw} maxLength={2} onChange={(e)=>setStRaw(e.target.value)} placeholder="st" />
+              <input className={`input ${error ? 'error' : ''}`} inputMode="numeric" type="text" value={stLbRaw} maxLength={2} onChange={(e)=>setStLbRaw(e.target.value)} placeholder="lb" />
+            </div>
           </div>
           {error && <div className="help-error">{error}</div>}
         </div>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -24,13 +24,12 @@ export default function Header(){
       <nav className="nav container">
         <Link href="/" className="brand" aria-label="Quick Calc home">
           <Image
-            src="/logos/icon-192.png"
+            src="/logos/icon-256.png"
             alt="Quick Calc logo"
-            width={34}
-            height={34}
+            width={48}
+            height={48}
             priority
           />
-          <span>Quick Calc</span>
         </Link>
 
         <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,9 +26,13 @@
 html,body{height:100%}
 body{
   margin:0;background:var(--bg);color:var(--fg);
-  font:16px/1.55 "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-size:16px;line-height:1.55;
+  font-family:var(--font-inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif);
   -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
 }
+
+@keyframes fadeInUp{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+header,main,footer{animation:fadeInUp .3s ease}
 
 .container{max-width:1100px;margin:0 auto;padding:28px}
 .header{position:sticky;top:0;z-index:50;backdrop-filter:saturate(120%) blur(10px);
@@ -36,15 +40,18 @@ body{
   background:color-mix(in oklab,var(--bg) 80%, transparent);
 }
 .nav{display:flex;align-items:center;justify-content:space-between;padding:14px 28px}
-.brand{display:flex;align-items:center;gap:12px;font-weight:800;letter-spacing:.2px}
+.brand{display:flex;align-items:center}
 .links{display:flex;gap:10px}
 .links a{padding:10px 14px;border-radius:12px;border:1px solid transparent;color:inherit;text-decoration:none;font-weight:600}
 .links a:hover{background:var(--card);border-color:var(--border);transition:background .2s ease}
 .links a[aria-current="page"]{background: color-mix(in oklab, var(--primary) 16%, var(--bg) 84%); border-color: var(--primary)}
 .menu-toggle{display:none;background:transparent;border:1px solid var(--border);border-radius:12px;padding:6px 10px;font-size:1.1rem}
 
-.hero{padding:28px;border:1px solid var(--border);border-radius:20px;background:var(--card);box-shadow:var(--shadow)}
-.card{background:var(--card);border:1px solid var(--border);border-radius:20px;padding:22px;box-shadow:var(--shadow)}
+.hero{padding:60px 28px;border:1px solid var(--border);border-radius:28px;text-align:center;background:linear-gradient(135deg,color-mix(in oklab,var(--primary) 15%,var(--card) 85%),var(--card));box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
+.card{background:var(--card);border:1px solid var(--border);border-radius:20px;padding:22px;box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
+.card:hover,.hero:hover{transform:translateY(-4px)}
+.hero h1{margin:0 0 12px;font-size:2rem}
+.hero p{margin:0 auto;max-width:480px}
 
 .input, select{
   width:100%;background:var(--white);border:1px solid var(--border);border-radius:12px;padding:12px 14px;color:inherit;font:inherit;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import Header from "./components/Header";
+
+const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: "Quick Calc — Clean, Fast Online Calculators",
@@ -17,10 +20,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.variable}>
       <body>
         <Header />
-        <main className="container" style={{paddingTop:24}}>{children}</main>
+        <main className="container" style={{ paddingTop: 24 }}>{children}</main>
         <footer className="footer container">
           <div>© {new Date().getFullYear()} Quick Calc • Fast, private, no sign-up</div>
         </footer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,8 +13,8 @@ const items = [
 export default function Home() {
   return (
     <>
-      <section className="card" style={{marginBottom:16}}>
-        <h1 style={{margin:"0 0 8px"}}>Modern calculators that just work</h1>
+      <section className="hero" style={{ marginBottom: 16 }}>
+        <h1>Fast online calculators, instant answers</h1>
         <p className="small">Clean design, instant results, no distractions. Currency & holidays powered by free public APIs.</p>
       </section>
       <section className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>


### PR DESCRIPTION
## Summary
- use Inter font globally and add subtle animations
- revamp hero and header with larger logo
- support stones and pounds on BMI calculator

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a7464fd9b08329954fc5870e4ae020