### PR TITLE
Add subtle imagery to homepage hero and tiles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,8 +47,12 @@ header,main,footer{animation:fadeInUp .3s ease}
 .links a[aria-current="page"]{background: color-mix(in oklab, var(--primary) 16%, var(--bg) 84%); border-color: var(--primary)}
 .menu-toggle{display:none;background:transparent;border:1px solid var(--border);border-radius:12px;padding:6px 10px;font-size:1.1rem}
 
-.hero{padding:60px 28px;border:1px solid var(--border);border-radius:28px;text-align:center;background:linear-gradient(135deg,color-mix(in oklab,var(--primary) 15%,var(--card) 85%),var(--card));box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
+.hero{padding:60px 28px;border:1px solid var(--border);border-radius:28px;text-align:center;background:linear-gradient(135deg,color-mix(in oklab,var(--primary) 15%,var(--card) 85%),var(--card));box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease;position:relative;overflow:hidden}
+.hero>*{position:relative;z-index:1}
 .card{background:var(--card);border:1px solid var(--border);border-radius:20px;padding:22px;box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
+.tile{position:relative;overflow:hidden}
+.tile>*{position:relative;z-index:1}
+.hero-img,.tile-img{position:absolute;inset:0;z-index:0}
 .card:hover,.hero:hover{transform:translateY(-4px)}
 .hero h1{margin:0 0 12px;font-size:2rem}
 .hero p{margin:0 auto;max-width:480px}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,11 @@ export const metadata: Metadata = {
       { url: "/logos/favicon-16.png", sizes: "16x16", type: "image/png" }
     ],
     apple: { url: "/logos/icon-180.png", sizes: "180x180", type: "image/png" }
+  },
+  openGraph: {
+    title: "Quick Calc — Clean, Fast Online Calculators",
+    description: "Modern, fast calculators for everyday tasks: BMI, mortgage, loans, age, date difference, tips, and business days.",
+    images: [{ url: "/images/hero.jpg", width: 1200, height: 630, alt: "Quick Calc calculators" }]
   }
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,88 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const items = [
-  { href: "/mortgage", title: "Mortgage Calculator", desc: "Monthly payment & totals (with FX conversion)" },
-  { href: "/loan", title: "Loan Calculator", desc: "Payments and total interest" },
-  { href: "/bmi", title: "BMI Calculator", desc: "Body mass index" },
-  { href: "/age", title: "Age Calculator", desc: "Exact age in Y/M/D" },
-  { href: "/date-diff", title: "Date Difference", desc: "Days and weeks between dates" },
-  { href: "/tip", title: "Tip Calculator", desc: "Split bill quickly" },
-  { href: "/business-days", title: "Business Days", desc: "Working days excluding weekends & holidays" }
+  {
+    href: "/mortgage",
+    title: "Mortgage Calculator",
+    desc: "Estimate your monthly home payment and total cost",
+    img: "/images/mortgage.jpg",
+    alt: "House keys and mortgage paperwork"
+  },
+  {
+    href: "/loan",
+    title: "Loan Calculator",
+    desc: "Plan payments and interest for any personal loan",
+    img: "/images/loan.jpg",
+    alt: "Loan documents and calculator"
+  },
+  {
+    href: "/bmi",
+    title: "BMI Calculator",
+    desc: "Check your body mass index from height and weight",
+    img: "/images/bmi.jpg",
+    alt: "Scale and measuring tape"
+  },
+  {
+    href: "/age",
+    title: "Age Calculator",
+    desc: "Find your exact age in years, months, and days",
+    img: "/images/age.jpg",
+    alt: "Clock and calendar for age"
+  },
+  {
+    href: "/date-diff",
+    title: "Date Difference",
+    desc: "Calculate days and weeks between dates",
+    img: "/images/date.jpg",
+    alt: "Calendar pages showing dates"
+  },
+  {
+    href: "/tip",
+    title: "Tip Calculator",
+    desc: "Quickly split restaurant bills and tips",
+    img: "/images/tips.jpg",
+    alt: "Receipt with tip calculation"
+  },
+  {
+    href: "/business-days",
+    title: "Business Days",
+    desc: "Count workdays excluding weekends and holidays",
+    img: "/images/business.jpg",
+    alt: "Office calendar for business days"
+  }
 ];
 
 export default function Home() {
   return (
     <>
       <section className="hero" style={{ marginBottom: 16 }}>
-        <h1>Fast online calculators, instant answers</h1>
-        <p className="small">Clean design, instant results, no distractions. Currency & holidays powered by free public APIs.</p>
+        <div className="hero-img">
+          <Image
+            src="/images/hero.jpg"
+            alt="Assorted calculator tools"
+            fill
+            priority
+            sizes="100vw"
+            style={{ objectFit: "cover", opacity: 0.2, pointerEvents: "none" }}
+          />
+        </div>
+        <h1>Quick Calc: fast online calculators, instant answers</h1>
+        <p className="small">Subtle visuals and clean design, no distractions. Currency & holidays powered by free public APIs.</p>
       </section>
       <section className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>
         {items.map(i => (
-          <Link key={i.href} href={i.href} className="card" style={{display:"block"}}>
+          <Link key={i.href} href={i.href} className="card tile" style={{display:"block"}}>
+            <div className="tile-img">
+              <Image
+                src={i.img}
+                alt={i.alt}
+                fill
+                sizes="(max-width: 600px) 100vw, 240px"
+                loading="lazy"
+                style={{ objectFit: "cover", opacity: 0.15, pointerEvents: "none" }}
+              />
+            </div>
             <div className="badge" style={{marginBottom:10}}>Calculator</div>
             <h2 style={{margin:"4px 0 6px"}}>{i.title}</h2>
             <p className="small" style={{margin:0}}>{i.desc}</p>


### PR DESCRIPTION
## Summary
- Showcase hero image with updated headline and copy.
- Add background images and alt text for each homepage calculator tile.
- Include Open Graph metadata for improved SEO.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a74e3147088329abf320cf8d6ecea0