### PR TITLE
Fix metadata export in BMI page

### DIFF
--- a/app/bmi/metadata.ts
+++ b/app/bmi/metadata.ts
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'BMI Calculator — Body Mass Index',
+  description: 'Compute your Body Mass Index and learn about BMI categories, formula and limitations.',
+  keywords: ['BMI', 'Body Mass Index', 'BMI calculator', 'health'],
+  openGraph: {
+    title: 'BMI Calculator — Body Mass Index',
+    description: 'Compute your Body Mass Index and learn about BMI categories, formula and limitations.',
+    images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator' }],
+  },
+};

--- a/app/bmi/page.tsx
+++ b/app/bmi/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useMemo, useState } from 'react';
-import type { Metadata } from 'next';
 import Image from 'next/image';
 import CalcShell from '../components/CalcShell';
 import BmiGauge from '../components/BmiGauge';
@@ -12,17 +11,6 @@ const LIMITS = {
   metric: { cm: { min: 90, max: 250 }, kg: { min: 25, max: 250 } },
   us:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, lb: { min: 60, max: 550 } },
   uk:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, st: { min: 4, max: 50 }, lb: { min: 0, max: 13 } }
-};
-
-export const metadata: Metadata = {
-  title: 'BMI Calculator — Body Mass Index',
-  description: 'Compute your Body Mass Index and learn about BMI categories, formula and limitations.',
-  keywords: ['BMI', 'Body Mass Index', 'BMI calculator', 'health'],
-  openGraph: {
-    title: 'BMI Calculator — Body Mass Index',
-    description: 'Compute your Body Mass Index and learn about BMI categories, formula and limitations.',
-    images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator' }],
-  },
 };
 
 


### PR DESCRIPTION
## Summary
- move BMI page metadata into dedicated `metadata.ts`
- remove disallowed metadata export from BMI page client component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a67bc758832996c40edb142fd7e2