### PR TITLE
feat: use Tomorrow font for hero and calculator titles

### DIFF
--- a/app/components/CalcShell.tsx
+++ b/app/components/CalcShell.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { ReactNode } from "react";
+import { Tomorrow } from "next/font/google";
 import "./CalcShell.css";
+
+const tomorrow = Tomorrow({ subsets: ["latin"], weight: ["700"], display: "swap" });
 
 export default function CalcShell({
   title, subtitle, children, result
@@ -8,7 +11,7 @@ export default function CalcShell({
   return (
     <section className="calc-shell grid grid-2">
       <div className="card">
-        <h1 style={{ marginTop: 0 }}>{title}</h1>
+        <h1 className={tomorrow.className} style={{ marginTop: 0 }}>{title}</h1>
         <p className="small" style={{ marginTop: 6 }}>{subtitle}</p>
         <div style={{ height: 12 }} />
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import Image from "next/image";
-import { Pacifico } from "next/font/google";
+import { Pacifico, Tomorrow } from "next/font/google";
 
 const pacifico = Pacifico({ subsets: ["latin"], weight: "400" });
+const tomorrow = Tomorrow({ subsets: ["latin"], weight: ["700"], display: "swap" });
 
 const items = [
   {
@@ -69,7 +70,7 @@ export default function Home() {
             sizes="100vw"
           />
         </div>
-        <h1>Quick Calc: fast online calculators, instant answers</h1>
+        <h1 className={tomorrow.className}>Quick Calc: fast online calculators, instant answers</h1>
         <p className="small">Subtle visuals and clean design, no distractions. Currency & holidays powered by free public APIs.</p>
 
       </section>


### PR DESCRIPTION
## Summary
- add Tomorrow Google Font and apply to home hero heading
- style calculator titles with Tomorrow font for consistent branding

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7b7301aa483299ef170c50d128bd9