### PR TITLE
Revamp homepage hero styling and messaging

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,8 @@
   --border:#D8D2E7;
   --radius:16px;
   --shadow:0 20px 40px rgba(152,24,142,.06), 0 2px 10px rgba(152,24,142,.04);
+  --navy:#0F1F3A;
+  --accent:#F6A313;
 }
 
 @media (prefers-color-scheme: dark){
@@ -49,19 +51,37 @@ header,main,footer{animation:fadeInUp .3s ease}
 .links a[aria-current="page"]{background: color-mix(in oklab, var(--primary) 16%, var(--bg) 84%); border-color: var(--primary)}
 .menu-toggle{display:none;background:transparent;border:1px solid var(--border);border-radius:12px;padding:6px 10px;font-size:1.1rem}
 
-.hero{padding:60px 28px;border:1px solid var(--border);border-radius:28px;text-align:center;background:linear-gradient(135deg,color-mix(in oklab,var(--primary) 15%,var(--card) 85%),var(--card));box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease;position:relative;overflow:hidden}
+.hero{
+  padding:clamp(48px,9vw,96px) 28px;
+  border:1px solid transparent;
+  border-radius:28px;
+  text-align:left;
+  background:linear-gradient(var(--card),var(--card)) padding-box,
+    linear-gradient(135deg,rgba(15,31,58,.2),rgba(15,31,58,0)) border-box;
+  box-shadow:0 8px 24px rgba(15,31,58,.06);
+  transition:transform .2s ease,box-shadow .2s ease;
+  position:relative;overflow:hidden;max-width:820px;margin:0 auto;
+}
 .hero>*{position:relative;z-index:1}
 .card{background:var(--card);border:1px solid var(--border);border-radius:20px;padding:22px;box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
-.tile{position:relative;overflow:hidden}
+.tile{position:relative;overflow:hidden;border:1px solid transparent;border-radius:20px;display:block;
+  background:linear-gradient(var(--card),var(--card)) padding-box,
+    linear-gradient(135deg,rgba(15,31,58,.15),rgba(15,31,58,0)) border-box;
+  box-shadow:0 4px 16px rgba(15,31,58,.06);
+}
 .tile>*{position:relative;z-index:1}
 .hero-img,.tile-img{position:absolute;inset:0;z-index:0}
 .hero-img img,.tile-img img{width:100%;height:100%;object-fit:cover;pointer-events:none}
-.hero-img img{opacity:.2}
-.tile-img img{opacity:.15}
-.hero-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to bottom,transparent,var(--card))}
+.hero-img img{object-position:right center;filter:grayscale(.4) blur(2px)}
+.tile-img img{opacity:.25;filter:grayscale(.4) blur(1px)}
+.hero-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to right,color-mix(in oklab,var(--navy) 10%, white),rgba(15,31,58,0))}
+.tile-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to top,color-mix(in oklab,var(--navy) 10%, white),rgba(15,31,58,0))}
+.tile h2{color:var(--navy);letter-spacing:-0.01em;margin:0 0 6px}
+.tile p{color:rgba(15,31,58,.7);margin:0;font-size:.9rem}
 .card:hover,.hero:hover{transform:translateY(-4px)}
-.hero h1{margin:0 0 12px;font-size:2rem}
-.hero p{margin:0 auto;max-width:480px}
+.hero h1{margin:0 0 16px;font-size:2.25rem;color:var(--navy);letter-spacing:-0.02em}
+.hero p{margin:0 0 24px;color:rgba(15,31,58,.7);line-height:1.6;max-width:620px}
+.hero-ctas{display:flex;gap:16px;flex-wrap:wrap}
 
 .input, select{
   width:100%;background:var(--white);border:1px solid var(--border);border-radius:12px;padding:12px 14px;color:inherit;font:inherit;
@@ -86,8 +106,11 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .footer{border-top:1px solid var(--border);padding:28px;margin-top:52px;color:var(--muted);font-size:.95rem}
 
 .small{color:var(--muted)}
-.btn{display:inline-flex;align-items:center;gap:8px;padding:12px 16px;border-radius:12px;border:1px solid var(--border);background:var(--primary);color:#fff;font-weight:700;cursor:pointer}
-.btn:hover{filter:brightness(1.07)}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 20px;border-radius:12px;font-weight:700;cursor:pointer;text-decoration:none;min-height:48px;border:1px solid transparent}
+.btn-primary{background:var(--accent);color:var(--navy)}
+.btn-ghost{background:transparent;border-color:var(--navy);color:var(--navy)}
+.btn-primary:hover{filter:brightness(1.05)}
+.btn-ghost:hover{background:rgba(15,31,58,.05)}
 
 /* Segmented tabs */
 .segment{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,8 @@ import Header from "./components/Header";
 const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
 
 export const metadata: Metadata = {
-  title: "Quick Calc — Clean, Fast Online Calculators",
-  description: "Modern, fast calculators for everyday tasks: BMI, mortgage, loans, age, date difference, tips, and business days.",
+  title: "Quick Calc — Calculators that just work",
+  description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
   themeColor: "#98188E",
   icons: {
     icon: [
@@ -17,8 +17,8 @@ export const metadata: Metadata = {
     apple: { url: "/logos/icon-180.png", sizes: "180x180", type: "image/png" }
   },
   openGraph: {
-    title: "Quick Calc — Clean, Fast Online Calculators",
-    description: "Modern, fast calculators for everyday tasks: BMI, mortgage, loans, age, date difference, tips, and business days.",
+    title: "Quick Calc — Calculators that just work",
+    description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
     images: [{ url: "/logos/social-1200.png", width: 1200, height: 1200, alt: "Quick Calc logo" }]
   }
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { Pacifico, Tomorrow } from "next/font/google";
+import { Outfit, Tomorrow } from "next/font/google";
 
-const pacifico = Pacifico({ subsets: ["latin"], weight: "400" });
+const outfit = Outfit({ subsets: ["latin"], weight: ["700"], display: "swap" });
 const tomorrow = Tomorrow({ subsets: ["latin"], weight: ["700"], display: "swap" });
 
 const items = [
@@ -70,13 +70,16 @@ export default function Home() {
             sizes="100vw"
           />
         </div>
-        <h1 className={tomorrow.className}>Quick Calc: fast online calculators, instant answers</h1>
-        <p className="small">Subtle visuals and clean design, no distractions. Currency & holidays powered by free public APIs.</p>
-
+        <h1 className={outfit.className}>Calculators that just work</h1>
+        <p>Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.</p>
+        <div className="hero-ctas">
+          <Link href="/bmi" className="btn btn-primary">Open BMI Calculator</Link>
+          <Link href="#calc-grid" className="btn btn-ghost">Browse all calculators</Link>
+        </div>
       </section>
-      <section className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>
+      <section id="calc-grid" className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>
         {items.map(i => (
-          <Link key={i.href} href={i.href} className="card tile" style={{display:"block"}}>
+          <Link key={i.href} href={i.href} className="card tile">
             <div className="tile-img">
               <Image
                 src={i.img}
@@ -86,8 +89,8 @@ export default function Home() {
                 loading="lazy"
               />
             </div>
-            <h2 style={{margin:"0 0 6px"}}>{i.title}</h2>
-            <p className="small" style={{margin:0}}>{i.desc}</p>
+            <h2 className={tomorrow.className}>{i.title}</h2>
+            <p>{i.desc}</p>
           </Link>
         ))}
       </section>


### PR DESCRIPTION
## Summary
- Increase hero text contrast with lighter gradient overlay for readability
- Restyle calculator tiles with gradient borders, soft shadows, and Tomorrow font for a cohesive look

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9801ee48329a6a94bcbc79b4aa2