### PR TITLE
Improve hero readability and unify tile styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,10 +72,10 @@ header,main,footer{animation:fadeInUp .3s ease}
 .tile>*{position:relative;z-index:1}
 .hero-img,.tile-img{position:absolute;inset:0;z-index:0}
 .hero-img img,.tile-img img{width:100%;height:100%;object-fit:cover;pointer-events:none}
-.hero-img img{object-position:right center;filter:grayscale(.4) blur(2px)}
-.tile-img img{opacity:.25;filter:grayscale(.4) blur(1px)}
-.hero-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to right,color-mix(in oklab,var(--navy) 10%, white),rgba(15,31,58,0))}
-.tile-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to top,color-mix(in oklab,var(--navy) 10%, white),rgba(15,31,58,0))}
+.hero-img img{object-position:right center;filter:grayscale(.4) blur(2px);opacity:.3}
+.tile-img img{opacity:.3;filter:grayscale(.4) blur(2px)}
+.hero-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to right,color-mix(in oklab,var(--navy) 5%, white),rgba(15,31,58,0))}
+.tile-img::before{content:"";position:absolute;inset:0;background:linear-gradient(to right,color-mix(in oklab,var(--navy) 5%, white),rgba(15,31,58,0))}
 .tile h2{color:var(--navy);letter-spacing:-0.01em;margin:0 0 6px}
 .tile p{color:rgba(15,31,58,.7);margin:0;font-size:.9rem}
 


### PR DESCRIPTION
## Summary
- Reduce hero image prominence for better text legibility
- Match calculator tiles' overlay and filter to hero for consistent style

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7bcf8e1448329b89779470b14dec2