### PR TITLE
chore: refine mobile header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quick Calc (Next.js)
+# QuickCalc (Next.js)
 
 Clean, modern calculators with consistent styling. Includes free APIs:
 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -22,24 +22,39 @@ export default function Header(){
   return (
     <header className="header">
       <nav className="nav container">
-        <Link href="/" className="brand" aria-label="Quick Calc home">
-          <Image
-            src="/logos/icon-256.png"
-            alt="Quick Calc logo"
-            width={48}
-            height={48}
-            priority
-          />
-        </Link>
-
         <button
           className="menu-toggle"
           aria-label="Toggle navigation"
           aria-expanded={open}
           onClick={() => setOpen(!open)}
         >
-          ☰
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
         </button>
+
+        <Link href="/" className="brand" aria-label="QuickCalc home">
+          <Image
+            src="/logos/icon-256.png"
+            alt="QuickCalc logo"
+            width={48}
+            height={48}
+            priority
+          />
+          <span className="brand-text">QuickCalc</span>
+        </Link>
 
         <div className={`links${open ? " open" : ""}`}>
           {nav.map(n => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -44,12 +44,13 @@ a{color:inherit;text-decoration:none}
   background:color-mix(in oklab,var(--bg) 80%, transparent);
 }
 .nav{display:flex;align-items:center;justify-content:space-between;padding:14px 28px}
-.brand{display:flex;align-items:center}
+.brand{display:flex;align-items:center;gap:8px}
+.brand-text{font-weight:700;font-size:1.25rem;}
 .links{display:flex;gap:10px}
 .links a{padding:10px 14px;border-radius:12px;border:1px solid transparent;color:inherit;text-decoration:none;font-weight:600}
 .links a:hover{background:var(--card);border-color:var(--border)}
 .links a[aria-current="page"]{background: color-mix(in oklab, var(--primary) 16%, var(--bg) 84%); border-color: var(--primary)}
-.menu-toggle{display:none;background:transparent;border:1px solid var(--border);border-radius:12px;padding:6px 10px;font-size:1.1rem}
+.menu-toggle{display:none;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:6px;color:var(--navy)}
 
 .hero{
   padding:clamp(48px,9vw,96px) 28px;
@@ -124,9 +125,22 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .help-error{ color:#ef4444; font-size:.9rem; margin-top:6px }
 
 @media (max-width:640px){
-  .nav{flex-wrap:wrap;}
-  .menu-toggle{display:block;}
+  .nav{flex-wrap:wrap;justify-content:center;position:relative;}
+  .brand{margin:0 auto;}
+  .menu-toggle{display:block;position:absolute;left:28px;top:14px;}
   .links{display:none;flex-direction:column;width:100%;margin-top:12px;gap:8px}
   .links.open{display:flex;}
   .links a{width:100%;}
+}
+
+@media (prefers-color-scheme:dark) and (max-width:640px){
+  :root{
+    --bg:#E9E6F6;
+    --fg:#1E1B36;
+    --muted:#7B77A7;
+    --card:#FFFFFF;
+    --border:#D8D2E7;
+    --shadow:0 20px 40px rgba(152,24,142,.06), 0 2px 10px rgba(152,24,142,.04);
+  }
+  .input, select{background:var(--white);}
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import Header from "./components/Header";
 const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
 
 export const metadata: Metadata = {
-  title: "Quick Calc — Calculators that just work",
+  title: "QuickCalc — Calculators that just work",
   description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
   themeColor: "#98188E",
   icons: {
@@ -17,9 +17,9 @@ export const metadata: Metadata = {
     apple: { url: "/logos/icon-180.png", sizes: "180x180", type: "image/png" }
   },
   openGraph: {
-    title: "Quick Calc — Calculators that just work",
+    title: "QuickCalc — Calculators that just work",
     description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
-    images: [{ url: "/logos/social-1200.png", width: 1200, height: 1200, alt: "Quick Calc logo" }]
+    images: [{ url: "/logos/social-1200.png", width: 1200, height: 1200, alt: "QuickCalc logo" }]
   }
 };
 
@@ -30,7 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Header />
         <main className="container" style={{ paddingTop: 24 }}>{children}</main>
         <footer className="footer container">
-          <div>© {new Date().getFullYear()} Quick Calc • Fast, private, no sign-up</div>
+          <div>© {new Date().getFullYear()} QuickCalc • Fast, private, no sign-up</div>
         </footer>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- lighten mobile appearance by mirroring desktop palette even when device prefers dark mode
- restyle mobile header with left-aligned hamburger, centered QuickCalc logo, and matching brand text
- update metadata and docs to reflect QuickCalc branding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8512ac6b08329a161011779107647