### PR TITLE
Add analytics tracking to site

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import Header from "./components/Header";
+import { Analytics } from "@vercel/analytics/next";
 
 const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
 
@@ -26,12 +28,28 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={inter.variable}>
+      <head>
+        <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-9ZHES1KSV3"
+        />
+        <Script id="google-analytics">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-9ZHES1KSV3');
+          `}
+        </Script>
+      </head>
       <body>
         <Header />
         <main className="container" style={{ paddingTop: 24 }}>{children}</main>
         <footer className="footer container">
           <div>© {new Date().getFullYear()} QuickCalc • Fast, private, no sign-up</div>
         </footer>
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "quick-calc",
       "version": "1.0.0",
       "dependencies": {
+        "@vercel/analytics": "^1.5.0",
         "date-fns": "3.6.0",
         "decimal.js": "10.4.3",
         "next": "14.2.7",
@@ -932,6 +933,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint --max-warnings=0"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
     "date-fns": "3.6.0",
     "decimal.js": "10.4.3",
     "next": "14.2.7",


### PR DESCRIPTION
## Summary
- include Google Analytics tag via `gtag.js`
- add Vercel Analytics for traffic insights

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a85706e5f48329a09d09b489b74e69