### PR TITLE
Always enable Google Analytics tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,6 +37,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
+            gtag('consent', 'default', {
+              ad_storage: 'granted',
+              analytics_storage: 'granted',
+              functionality_storage: 'granted',
+              personalization_storage: 'granted',
+              security_storage: 'granted'
+            });
             gtag('js', new Date());
 
             gtag('config', 'G-9ZHES1KSV3');


### PR DESCRIPTION
## Summary
- Always grant consent for Google Analytics so tracking is enabled by default

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a85c2769a48329b2c9c1d21ab8550c