### PR TITLE
Update base domain for sitemap to quickcalc.me

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # Base URL used for generating absolute links in sitemap and metadata
-SITE_URL=https://example.com
+SITE_URL=https://quickcalc.me

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm run dev
 # open http://localhost:3000
 ```
 
-Set `SITE_URL` in a `.env` file to your production domain so the sitemap and
+Set `SITE_URL` in a `.env` file to your production domain (e.g., `https://quickcalc.me`) so the sitemap and
 robots.txt include the correct absolute links.
 
 ## Build

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import Header from "./components/Header";
 import { Analytics } from "@vercel/analytics/next";
 
 const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
-const baseUrl = process.env.SITE_URL ?? "https://example.com";
+const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
 
 export const metadata: Metadata = {
   title: "QuickCalc — Calculators that just work",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { Outfit } from "next/font/google";
 import type { Metadata } from "next";
 
-const baseUrl = process.env.SITE_URL ?? "https://example.com";
+const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
 
 export const metadata: Metadata = {
   title: "QuickCalc – Free Online Calculators",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const base = process.env.SITE_URL ?? "https://example.com";
+  const base = process.env.SITE_URL ?? "https://quickcalc.me";
   return {
     rules: {
       userAgent: "*",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = process.env.SITE_URL ?? "https://example.com";
+  const base = process.env.SITE_URL ?? "https://quickcalc.me";
   const routes = ["","/bmi","/mortgage","/loan","/age","/date-diff","/tip","/business-days"];
   return routes.map((r) => ({
     url: `${base}${r}`,


### PR DESCRIPTION
## Summary
- point default SITE_URL to `https://quickcalc.me`
- ensure layout, home page, robots and sitemap use the new domain
- document production domain example in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a86b1777a48329b6576a3fbbddd65c