### PR TITLE
Add ads.txt for AdSense verification

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1257499604453174, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- add `ads.txt` file under `public` for Google AdSense verification

No tests were run.

------
https://chatgpt.com/codex/tasks/task_e_68a87c43c08c8329a2dc610121fb906b