### PR TITLE
Link to Utilixy and drop dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,17 +13,6 @@
   --accent:#F6A313;
 }
 
-@media (prefers-color-scheme: dark){
-  :root{
-    --bg:#1B1521;
-    --fg:#F5F4F9;
-    --muted:#B9B6D9;
-    --card:#241E2C;
-    --border:#3B3348;
-    --shadow:0 14px 32px rgba(0,0,0,.45), 0 2px 8px rgba(0,0,0,.4);
-  }
-}
-
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
@@ -87,7 +76,6 @@ a{color:inherit;text-decoration:none}
 .input, select{
   width:100%;background:var(--white);border:1px solid var(--border);border-radius:12px;padding:12px 14px;color:inherit;font:inherit;
 }
-@media(prefers-color-scheme:dark){ .input, select{ background:#0c121c; } }
 .input:focus, select:focus{outline:none;border-color:var(--primary);box-shadow:0 0 0 3px color-mix(in oklab, var(--primary) 36%, transparent)}
 
 label{display:block;margin-bottom:6px;font-weight:600}
@@ -113,6 +101,23 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .btn-primary:hover{filter:brightness(1.05)}
 .btn-ghost:hover{background:rgba(15,31,58,.05)}
 
+.fancy-link{
+  position:relative;
+  font-weight:700;
+  background:linear-gradient(90deg,var(--accent),var(--primary));
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+}
+.fancy-link::after{
+  content:"";
+  position:absolute;
+  left:0;
+  bottom:-2px;
+  width:100%;
+  height:2px;
+  background:linear-gradient(90deg,var(--accent),var(--primary));
+}
+
 /* Segmented tabs */
 .segment{
   display:inline-flex; background:var(--white); border:1px solid var(--border); border-radius:12px; padding:3px;
@@ -133,14 +138,3 @@ label{display:block;margin-bottom:6px;font-weight:600}
   .links a{width:100%;}
 }
 
-@media (prefers-color-scheme:dark) and (max-width:640px){
-  :root{
-    --bg:#E9E6F6;
-    --fg:#1E1B36;
-    --muted:#7B77A7;
-    --card:#FFFFFF;
-    --border:#D8D2E7;
-    --shadow:0 20px 40px rgba(152,24,142,.06), 0 2px 10px rgba(152,24,142,.04);
-  }
-  .input, select{background:var(--white);}
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
 export const metadata: Metadata = {
   title: "QuickCalc – Free Online Calculators",
   description:
-    "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations.",
+    "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations. Need PDF or image conversions? Try Utilixy.",
   keywords: [
     "free online calculators",
     "mortgage calculator",
@@ -17,13 +17,16 @@ export const metadata: Metadata = {
     "age calculator",
     "tip calculator",
     "date difference calculator",
-    "business days calculator"
+    "business days calculator",
+    "pdf converter",
+    "image converter",
+    "utilixy"
   ],
   alternates: { canonical: '/' },
   openGraph: {
     title: "QuickCalc – Free Online Calculators",
     description:
-      "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations.",
+      "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations. Need PDF or image conversions? Try Utilixy.",
     url: baseUrl,
     images: [
       {
@@ -107,7 +110,15 @@ export default function Home() {
         <p>Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.</p>
         <div className="hero-ctas">
           <Link href="/bmi" className="btn btn-primary">Open BMI Calculator</Link>
-          <Link href="#calc-grid" className="btn btn-ghost">Browse all calculators</Link>
+          <a
+            href="https://utilixy.com"
+            target="_blank"
+            rel="noopener"
+            className="btn btn-ghost"
+            title="Utilixy – Free PDF, image, and data converters"
+          >
+            Visit utilixy.com
+          </a>
         </div>
       </section>
       <section id="calc-grid" className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>
@@ -134,6 +145,7 @@ export default function Home() {
           href="https://utilixy.com"
           target="_blank"
           rel="noopener"
+          className="fancy-link"
           title="Utilixy – Free PDF, image, and data converters"
         >
           Utilixy


### PR DESCRIPTION
## Summary
- Replace hero "Browse all calculators" CTA with external link to utilixy.com
- Highlight Utilixy with a gradient text link and updated SEO metadata
- Remove dark mode styles for a consistent light theme

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a882c4e7d88329baf3bcfd423477af