### PR TITLE
Improve mortgage calculator form and currency handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -92,6 +92,8 @@ label{display:block;margin-bottom:6px;font-weight:600}
 }
 
 .badge{display:inline-flex;gap:6px;align-items:center;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--white);color:var(--muted);font-weight:600}
+.section-title{margin:24px 0 12px;font-weight:700;color:var(--primary)}
+.form-section{margin-top:12px}
 .footer{border-top:1px solid var(--border);padding:28px;margin-top:52px;color:var(--muted);font-size:.95rem}
 
 .small{color:var(--muted)}

--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState } from "react";
 import CalcShell from "../components/CalcShell";
 import { amortizedPayment } from "@/lib/finance";
 
@@ -15,62 +15,65 @@ export default function MortgageClient(){
   const [propertyTax, setPropertyTax] = useState(2400); // annual
   const [insurance, setInsurance] = useState(1200); // annual
   const [hoa, setHoa] = useState(0); // monthly
-  const [fx, setFx] = useState<{ rates?: Record<string, number> }>({});
-
-  useEffect(() => {
-    const symbols = currencies.filter(c => c !== currency).join(",");
-    fetch(`/api/fx?base=${currency}&symbols=${symbols}`).then(r => r.json()).then(setFx).catch(() => {});
-  }, [currency]);
+  const [stampDuty, setStampDuty] = useState(0); // one-off
+  const [fees, setFees] = useState(0); // one-off
 
   const principal = Math.max(amount - down, 0);
   const m = useMemo(() => amortizedPayment(principal, rate, years * 12), [principal, rate, years]);
   const monthlyTax = propertyTax / 12;
   const monthlyIns = insurance / 12;
   const monthlyTotal = useMemo(() => m + monthlyTax + monthlyIns + hoa, [m, monthlyTax, monthlyIns, hoa]);
-  const total = useMemo(() => m * years * 12, [m, years]);
-  const interest = useMemo(() => total - principal, [total, principal]);
-
-  const conversions = Object.entries(fx.rates || {}).map(([code, rate]) => ({
-    code,
-    value: Math.round(monthlyTotal * rate)
-  }));
+  const total = useMemo(() => monthlyTotal * years * 12, [monthlyTotal, years]);
+  const interest = useMemo(() => m * years * 12 - principal, [m, years, principal]);
+  const upfront = useMemo(() => down + stampDuty + fees, [down, stampDuty, fees]);
 
   return (
     <CalcShell
       title="Mortgage Calculator"
-      subtitle="Estimate repayments with taxes, insurance and fees. FX conversion included."
+      subtitle="Estimate repayments with taxes, insurance and fees."
       result={
         <>
           <div className="kpi"><span>Monthly ({currency})</span><span>{symbolMap[currency]}{Math.round(monthlyTotal).toLocaleString()}</span></div>
-          {conversions.map(c => (
-            <div key={c.code}>
-              <div style={{ height: 10 }} />
-              <div className="kpi"><span>Monthly ({c.code})</span><span>{symbolMap[c.code as keyof typeof symbolMap]}{c.value.toLocaleString()}</span></div>
-            </div>
-          ))}
           <div style={{ height: 10 }} />
           <div className="kpi"><span>Total interest</span><span>{symbolMap[currency]}{Math.round(interest).toLocaleString()}</span></div>
           <div style={{ height: 10 }} />
           <div className="kpi"><span>Total paid</span><span>{symbolMap[currency]}{Math.round(total).toLocaleString()}</span></div>
-          <p className="small">Assumes fixed rate and standard amortization.</p>
+          <div style={{ height: 10 }} />
+          <div className="kpi"><span>Upfront costs</span><span>{symbolMap[currency]}{Math.round(upfront).toLocaleString()}</span></div>
+          <p className="small">Estimates only. Taxes and fees are approximations.</p>
         </>
       }
     >
-      <div className="grid grid-2">
-        <div><label>Home price ({symbolMap[currency]})</label><input className="input" type="number" step={1000} value={amount} onChange={e => setAmount(+e.target.value)} /></div>
-        <div><label>Down payment ({symbolMap[currency]})</label><input className="input" type="number" step={1000} value={down} onChange={e => setDown(+e.target.value)} /></div>
-        <div><label>Interest rate (% p.a.)</label><input className="input" type="number" step="0.01" value={rate} onChange={e => setRate(+e.target.value)} /></div>
-        <div><label>Term (years)</label><input className="input" type="number" min={1} max={40} value={years} onChange={e => setYears(+e.target.value)} /></div>
-        <div><label>Property tax ({symbolMap[currency]}/yr)</label><input className="input" type="number" step={100} value={propertyTax} onChange={e => setPropertyTax(+e.target.value)} /></div>
-        <div><label>Home insurance ({symbolMap[currency]}/yr)</label><input className="input" type="number" step={100} value={insurance} onChange={e => setInsurance(+e.target.value)} /></div>
-        <div><label>HOA/fees ({symbolMap[currency]}/mo)</label><input className="input" type="number" step={10} value={hoa} onChange={e => setHoa(+e.target.value)} /></div>
-        <div>
-          <label>Currency</label>
-          <select className="input" value={currency} onChange={e => setCurrency(e.target.value as typeof currencies[number])}>
-            {currencies.map(c => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
+      <div className="form-section">
+        <h2 className="section-title">Loan basics</h2>
+        <div className="grid grid-2">
+          <div><label>Home price <span className="label-unit">{symbolMap[currency]}</span></label><input className="input" type="number" step={1000} value={amount} onChange={e => setAmount(+e.target.value)} /></div>
+          <div><label>Deposit <span className="label-unit">{symbolMap[currency]}</span></label><input className="input" type="number" step={1000} value={down} onChange={e => setDown(+e.target.value)} /></div>
+          <div><label>Rate <span className="label-unit">% p.a.</span></label><input className="input" type="number" step="0.01" value={rate} onChange={e => setRate(+e.target.value)} /></div>
+          <div><label>Term <span className="label-unit">years</span></label><input className="input" type="number" min={1} max={40} value={years} onChange={e => setYears(+e.target.value)} /></div>
+        </div>
+      </div>
+      <div className="form-section">
+        <h2 className="section-title">Recurring costs</h2>
+        <div className="grid grid-2">
+          <div><label>Property tax <span className="label-unit">{symbolMap[currency]}/yr</span></label><input className="input" type="number" step={100} value={propertyTax} onChange={e => setPropertyTax(+e.target.value)} /></div>
+          <div><label>Insurance <span className="label-unit">{symbolMap[currency]}/yr</span></label><input className="input" type="number" step={100} value={insurance} onChange={e => setInsurance(+e.target.value)} /></div>
+          <div><label>HOA/fees <span className="label-unit">{symbolMap[currency]}/mo</span></label><input className="input" type="number" step={10} value={hoa} onChange={e => setHoa(+e.target.value)} /></div>
+          <div>
+            <label>Currency</label>
+            <select className="input" value={currency} onChange={e => setCurrency(e.target.value as typeof currencies[number])}>
+              {currencies.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+      <div className="form-section">
+        <h2 className="section-title">One-off costs</h2>
+        <div className="grid grid-2">
+          <div><label>Stamp duty <span className="label-unit">{symbolMap[currency]}</span></label><input className="input" type="number" step={100} value={stampDuty} onChange={e => setStampDuty(+e.target.value)} /></div>
+          <div><label>Other fees <span className="label-unit">{symbolMap[currency]}</span></label><input className="input" type="number" step={100} value={fees} onChange={e => setFees(+e.target.value)} /></div>
         </div>
       </div>
     </CalcShell>

--- a/app/mortgage/page.tsx
+++ b/app/mortgage/page.tsx
@@ -3,12 +3,12 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Mortgage Calculator — Global Home Loan Estimates',
-  description: 'Calculate mortgage payments worldwide with taxes, insurance and fees in multiple currencies.',
-  keywords: ['mortgage calculator', 'home loan', 'amortization', 'property tax', 'home insurance'],
+  description: 'Calculate mortgage payments worldwide with clear sections for loan basics, recurring charges and one-off fees in your chosen currency.',
+  keywords: ['mortgage calculator', 'home loan', 'amortization', 'property tax', 'home insurance', 'stamp duty', 'upfront fees'],
   alternates: { canonical: '/mortgage' },
   openGraph: {
     title: 'Mortgage Calculator — Global Home Loan Estimates',
-    description: 'Calculate mortgage payments worldwide with taxes, insurance and fees in multiple currencies.',
+    description: 'Calculate mortgage payments worldwide with clear sections for loan basics, recurring charges and one-off fees in your chosen currency.',
     images: [{ url: '/images/mortgage.jpg', width: 1200, height: 630, alt: 'Mortgage calculator' }]
   }
 };


### PR DESCRIPTION
## Summary
- restyled mortgage calculator with prominent section titles and upfront cost inputs
- restrict results to selected currency and show upfront costs
- update mortgage page SEO metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a8cc58407c83298c48930b6b092463