### PR TITLE
Improve mortgage form styling and currency handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -92,6 +92,8 @@ label{display:block;margin-bottom:6px;font-weight:600}
 }
 
 .badge{display:inline-flex;gap:6px;align-items:center;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--white);color:var(--muted);font-weight:600}
+.form-section{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:20px;margin-top:20px}
+.section-title{margin:0 0 16px;font-size:1.1rem;font-weight:700;color:var(--navy)}
 .footer{border-top:1px solid var(--border);padding:28px;margin-top:52px;color:var(--muted);font-size:.95rem}
 
 .small{color:var(--muted)}


### PR DESCRIPTION
## Summary
- Style mortgage form sections with prominent titles and cleaner labels
- Only display selected currency in results
- Add CSS rules for new form sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d2d40dbc832982fd21393955915b