### PR TITLE
Expand mortgage tooltips with Wikipedia-based definitions

### DIFF
--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -130,7 +130,7 @@ export default function MortgageClient() {
         <div>
           <label htmlFor="country" className="label-tooltip">
             Country
-            <span className="tooltip-icon" title="Country whose mortgage rules apply" aria-label="Country whose mortgage rules apply">?</span>
+            <span className="tooltip-icon" title="Select the country, a distinct territorial entity, to apply its mortgage rules" aria-label="Select the country, a distinct territorial entity, to apply its mortgage rules">?</span>
           </label>
           <select id="country" className="input" value={country} onChange={e => setCountry(e.target.value as CountryCode)}>
             {countries.map(c => (
@@ -141,7 +141,7 @@ export default function MortgageClient() {
         <div>
           <label htmlFor="currency" className="label-tooltip">
             Currency
-            <span className="tooltip-icon" title="Currency used for display" aria-label="Currency used for display">?</span>
+            <span className="tooltip-icon" title="Currency is a system of money; choose the unit used to display amounts" aria-label="Currency is a system of money; choose the unit used to display amounts">?</span>
           </label>
           <select id="currency" className="input" value={currency} onChange={e => setCurrency(e.target.value)}>
             {[...new Set([schema.currency, 'USD', 'EUR', 'GBP'])].map(c => (

--- a/app/mortgage/page.tsx
+++ b/app/mortgage/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
   description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees and upfront costs.',
-  keywords: ['mortgage calculator', 'home loan', 'amortization', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'condo fees', 'ground rent', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
+  keywords: ['mortgage calculator', 'home loan', 'amortization', 'down payment', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'condo fees', 'ground rent', 'stamp duty', 'CMHC insurance', 'LMI', 'notary fees', 'processing fee', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
   alternates: { canonical: '/mortgage' },
   openGraph: {
     title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',

--- a/lib/mortgage.ts
+++ b/lib/mortgage.ts
@@ -36,15 +36,15 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-US',
     fields: {
       basics: [
-        { id: 'price', label: 'Property price', default: 400000, step: 1000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 80000, step: 1000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Loan term (years)', default: 30, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 4.5, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Property price', default: 400000, step: 1000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Down payment', default: 80000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Loan term (years)', default: 30, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 4.5, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'taxPct', label: 'Property tax %', default: 1.2, step: 0.1, type: 'percent', tooltip: 'Average county property tax percent.' },
-        { id: 'ins', label: 'Homeowners insurance', default: 1200, step: 100, annual: true, tooltip: 'Estimated yearly homeowner insurance.' },
-        { id: 'hoa', label: 'HOA fees', default: 0, step: 10, tooltip: 'Monthly Homeowners Association fees.' },
+        { id: 'taxPct', label: 'Property tax %', default: 1.2, step: 0.1, type: 'percent', tooltip: 'Ad valorem tax on property value expressed as a percentage.' },
+        { id: 'ins', label: 'Homeowners insurance', default: 1200, step: 100, annual: true, tooltip: 'Insurance covering a private residence and its contents.' },
+        { id: 'hoa', label: 'HOA fees', default: 0, step: 10, tooltip: 'Dues paid to a homeowners association for shared amenities.' },
       ],
       upfront: []
     },
@@ -65,18 +65,18 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-CA',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 500000, step: 1000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 100000, step: 1000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Amortization (years)', default: 25, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 4.0, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Price', default: 500000, step: 1000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Down payment', default: 100000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Amortization (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 4.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'taxPct', label: 'Property tax %', default: 1.0, step: 0.1, type: 'percent', tooltip: 'Property tax as a percent of home price.' },
-        { id: 'ins', label: 'Home insurance', default: 1200, step: 100, annual: true, tooltip: 'Estimated yearly home insurance.' },
-        { id: 'condo', label: 'Condo fees', default: 0, step: 10, tooltip: 'Monthly condominium or strata fees.' },
+        { id: 'taxPct', label: 'Property tax %', default: 1.0, step: 0.1, type: 'percent', tooltip: 'Ad valorem tax on property value expressed as a percentage.' },
+        { id: 'ins', label: 'Home insurance', default: 1200, step: 100, annual: true, tooltip: 'Insurance covering a private residence and its contents.' },
+        { id: 'condo', label: 'Condo fees', default: 0, step: 10, tooltip: 'Monthly condominium association fees for shared property upkeep.' },
       ],
       upfront: [
-        { id: 'cmhc', label: 'CMHC insurance %', default: 0, step: 0.1, type: 'percent', tooltip: 'CMHC mortgage insurance percentage.' }
+        { id: 'cmhc', label: 'CMHC insurance %', default: 0, step: 0.1, type: 'percent', tooltip: 'Mortgage insurance from CMHC that protects lenders when the down payment is small.' }
       ]
     },
     calculate: (v) => {
@@ -99,17 +99,17 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-GB',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 350000, step: 1000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 70000, step: 1000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 3.5, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Price', default: 350000, step: 1000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Deposit', default: 70000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 3.5, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'ground', label: 'Ground rent & service', default: 0, step: 10, tooltip: 'Monthly ground rent and service charges.' },
-        { id: 'ins', label: 'Insurance', default: 1000, step: 100, annual: true, tooltip: 'Estimated yearly building insurance.' },
+        { id: 'ground', label: 'Ground rent & service', default: 0, step: 10, tooltip: 'Regular ground rent and service charges paid by leaseholders.' },
+        { id: 'ins', label: 'Insurance', default: 1000, step: 100, annual: true, tooltip: 'Insurance covering the building against damage or loss.' },
       ],
       upfront: [
-        { id: 'stamp', label: 'Stamp duty %', default: 5, step: 0.1, type: 'percent', tooltip: 'Stamp duty rate applied to purchase price.' }
+        { id: 'stamp', label: 'Stamp duty %', default: 5, step: 0.1, type: 'percent', tooltip: 'Stamp duty land tax charged on property purchases.' }
       ]
     },
     calculate: (v) => {
@@ -129,17 +129,17 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-AU',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 600000, step: 1000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 120000, step: 1000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Term (years)', default: 30, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 5.0, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Price', default: 600000, step: 1000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Deposit', default: 120000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Term (years)', default: 30, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 5.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'strata', label: 'Strata/body-corp fees', default: 0, step: 10, tooltip: 'Monthly strata or body corporate fees.' },
-        { id: 'ins', label: 'Insurance', default: 1000, step: 100, annual: true, tooltip: 'Estimated yearly home insurance.' },
+        { id: 'strata', label: 'Strata/body-corp fees', default: 0, step: 10, tooltip: 'Contributions to a body corporate for shared property upkeep.' },
+        { id: 'ins', label: 'Insurance', default: 1000, step: 100, annual: true, tooltip: 'Insurance covering a private residence and its contents.' },
       ],
       upfront: [
-        { id: 'lmi', label: 'LMI %', default: 0, step: 0.1, type: 'percent', tooltip: 'Lenders Mortgage Insurance percentage.' }
+        { id: 'lmi', label: 'LMI %', default: 0, step: 0.1, type: 'percent', tooltip: 'Lenders Mortgage Insurance that protects the lender if the borrower defaults.' }
       ]
     },
     calculate: (v) => {
@@ -159,17 +159,17 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 300000, step: 1000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 60000, step: 1000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 3.8, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Price', default: 300000, step: 1000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Deposit', default: 60000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 3.8, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'taxPct', label: 'Property tax %', default: 1.0, step: 0.1, type: 'percent', tooltip: 'Property tax as a percent of home price.' },
-        { id: 'ins', label: 'Insurance', default: 800, step: 100, annual: true, tooltip: 'Estimated yearly insurance.' },
+        { id: 'taxPct', label: 'Property tax %', default: 1.0, step: 0.1, type: 'percent', tooltip: 'Ad valorem tax on property value expressed as a percentage.' },
+        { id: 'ins', label: 'Insurance', default: 800, step: 100, annual: true, tooltip: 'Insurance covering a private residence and its contents.' },
       ],
       upfront: [
-        { id: 'notary', label: 'Notary/registration fees %', default: 2, step: 0.1, type: 'percent', tooltip: 'Notary and registration fees percentage.' }
+        { id: 'notary', label: 'Notary/registration fees %', default: 2, step: 0.1, type: 'percent', tooltip: 'Percentage paid for notary and property registration services.' }
       ]
     },
     calculate: (v) => {
@@ -190,17 +190,17 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-IN',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 5000000, step: 10000, tooltip: 'Total purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 1000000, step: 10000, tooltip: 'Initial amount you pay upfront.' },
-        { id: 'term', label: 'Term (years)', default: 20, step: 1, tooltip: 'Length of the loan in years.' },
-        { id: 'rate', label: 'Rate (APR %)', default: 8.0, step: 0.01, tooltip: 'Annual percentage interest rate.' },
+        { id: 'price', label: 'Price', default: 5000000, step: 10000, tooltip: 'Purchase price of the property.' },
+        { id: 'down', label: 'Down payment', default: 1000000, step: 10000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
+        { id: 'term', label: 'Term (years)', default: 20, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'rate', label: 'Rate (APR %)', default: 8.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'tax', label: 'Property tax', default: 10000, step: 1000, annual: true, tooltip: 'Yearly property tax amount.' },
-        { id: 'maint', label: 'Maintenance', default: 0, step: 100, tooltip: 'Monthly maintenance or society charges.' },
+        { id: 'tax', label: 'Property tax', default: 10000, step: 1000, annual: true, tooltip: 'Yearly municipal tax on real estate.' },
+        { id: 'maint', label: 'Maintenance', default: 0, step: 100, tooltip: 'Monthly maintenance or society charges for shared services.' },
       ],
       upfront: [
-        { id: 'proc', label: 'Processing fee %', default: 1, step: 0.1, type: 'percent', tooltip: 'One-time loan processing fee percentage.' }
+        { id: 'proc', label: 'Processing fee %', default: 1, step: 0.1, type: 'percent', tooltip: 'One-time loan origination fee as a percentage of the principal.' }
       ]
     },
     calculate: (v) => {


### PR DESCRIPTION
## Summary
- enrich mortgage field tooltips with concise definitions sourced from Wikipedia
- document country and currency selectors for clarity
- broaden mortgage page keywords for improved SEO

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8d91cb5988329bc16c95c304d225a