### PR TITLE
fix mortgage tooltip focus

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,7 @@ a{color:inherit;text-decoration:none}
 label{display:block;margin-bottom:6px;font-weight:600}
 .label-unit{display:block;margin-bottom:4px;font-weight:600;font-size:.85rem;color:var(--muted)}
 .label-tooltip{display:flex;align-items:center;gap:4px;margin-bottom:6px;font-weight:600}
+.label-tooltip label{margin:0}
 .tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:help}
 .label-tooltip .tooltip-icon:hover{background:var(--primary)}
 

--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -85,10 +85,10 @@ export default function MortgageClient() {
             }
             return (
               <div key={f.id}>
-                <label htmlFor={f.id} className="label-tooltip">
-                  {label}
+                <div className="label-tooltip">
+                  <label htmlFor={f.id}>{label}</label>
                   <span className="tooltip-icon" title={f.tooltip} aria-label={f.tooltip}>?</span>
-                </label>
+                </div>
                 <input
                   id={f.id}
                   className="input"
@@ -96,6 +96,7 @@ export default function MortgageClient() {
                   step={f.step || 1}
                   value={values[f.id] ?? ''}
                   onChange={e => update(f.id, +e.target.value)}
+                  title={f.tooltip}
                 />
               </div>
             );
@@ -128,22 +129,46 @@ export default function MortgageClient() {
     >
       <div className="grid grid-2">
         <div>
-          <label htmlFor="country" className="label-tooltip">
-            Country
-            <span className="tooltip-icon" title="Select the country, a distinct territorial entity, to apply its mortgage rules" aria-label="Select the country, a distinct territorial entity, to apply its mortgage rules">?</span>
-          </label>
-          <select id="country" className="input" value={country} onChange={e => setCountry(e.target.value as CountryCode)}>
+          <div className="label-tooltip">
+            <label htmlFor="country">Country</label>
+            <span
+              className="tooltip-icon"
+              title="Select the country, a distinct territorial entity, to apply its mortgage rules"
+              aria-label="Select the country, a distinct territorial entity, to apply its mortgage rules"
+            >
+              ?
+            </span>
+          </div>
+          <select
+            id="country"
+            className="input"
+            value={country}
+            onChange={e => setCountry(e.target.value as CountryCode)}
+            title="Select the country, a distinct territorial entity, to apply its mortgage rules"
+          >
             {countries.map(c => (
               <option key={c} value={c}>{c}</option>
             ))}
           </select>
         </div>
         <div>
-          <label htmlFor="currency" className="label-tooltip">
-            Currency
-            <span className="tooltip-icon" title="Currency is a system of money; choose the unit used to display amounts" aria-label="Currency is a system of money; choose the unit used to display amounts">?</span>
-          </label>
-          <select id="currency" className="input" value={currency} onChange={e => setCurrency(e.target.value)}>
+          <div className="label-tooltip">
+            <label htmlFor="currency">Currency</label>
+            <span
+              className="tooltip-icon"
+              title="Currency is a system of money; choose the unit used to display amounts"
+              aria-label="Currency is a system of money; choose the unit used to display amounts"
+            >
+              ?
+            </span>
+          </div>
+          <select
+            id="currency"
+            className="input"
+            value={currency}
+            onChange={e => setCurrency(e.target.value)}
+            title="Currency is a system of money; choose the unit used to display amounts"
+          >
             {[...new Set([schema.currency, 'USD', 'EUR', 'GBP'])].map(c => (
               <option key={c} value={c}>{c}</option>
             ))}


### PR DESCRIPTION
## Summary
- prevent tooltip icons from focusing inputs in mortgage calculator
- update tooltip styles to match new structure
- add title tooltips to all mortgage inputs and selectors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8db40d7c08329b2a09e31cbd69fe5