### PR TITLE
Improve mortgage input tooltips

### DIFF
--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -87,7 +87,9 @@ export default function MortgageClient() {
               <div key={f.id}>
                 <div className="label-tooltip">
                   <label htmlFor={f.id}>{label}</label>
-                  <span className="tooltip-icon" title={f.tooltip} aria-label={f.tooltip}>?</span>
+                  {f.tooltip && (
+                    <span className="tooltip-icon" title={f.tooltip} aria-label={f.tooltip}>?</span>
+                  )}
                 </div>
                 <input
                   id={f.id}
@@ -96,7 +98,7 @@ export default function MortgageClient() {
                   step={f.step || 1}
                   value={values[f.id] ?? ''}
                   onChange={e => update(f.id, +e.target.value)}
-                  title={f.tooltip}
+                  {...(f.tooltip ? { title: f.tooltip } : {})}
                 />
               </div>
             );
@@ -131,20 +133,12 @@ export default function MortgageClient() {
         <div>
           <div className="label-tooltip">
             <label htmlFor="country">Country</label>
-            <span
-              className="tooltip-icon"
-              title="Select the country, a distinct territorial entity, to apply its mortgage rules"
-              aria-label="Select the country, a distinct territorial entity, to apply its mortgage rules"
-            >
-              ?
-            </span>
           </div>
           <select
             id="country"
             className="input"
             value={country}
             onChange={e => setCountry(e.target.value as CountryCode)}
-            title="Select the country, a distinct territorial entity, to apply its mortgage rules"
           >
             {countries.map(c => (
               <option key={c} value={c}>{c}</option>
@@ -154,20 +148,12 @@ export default function MortgageClient() {
         <div>
           <div className="label-tooltip">
             <label htmlFor="currency">Currency</label>
-            <span
-              className="tooltip-icon"
-              title="Currency is a system of money; choose the unit used to display amounts"
-              aria-label="Currency is a system of money; choose the unit used to display amounts"
-            >
-              ?
-            </span>
           </div>
           <select
             id="currency"
             className="input"
             value={currency}
             onChange={e => setCurrency(e.target.value)}
-            title="Currency is a system of money; choose the unit used to display amounts"
           >
             {[...new Set([schema.currency, 'USD', 'EUR', 'GBP'])].map(c => (
               <option key={c} value={c}>{c}</option>

--- a/lib/mortgage.ts
+++ b/lib/mortgage.ts
@@ -36,9 +36,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-US',
     fields: {
       basics: [
-        { id: 'price', label: 'Property price', default: 400000, step: 1000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 80000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Loan term (years)', default: 30, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Property price', default: 400000, step: 1000 },
+        { id: 'down', label: 'Down payment', default: 80000, step: 1000 },
+        { id: 'term', label: 'Loan term (years)', default: 30, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 4.5, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
@@ -65,9 +65,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-CA',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 500000, step: 1000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 100000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Amortization (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Price', default: 500000, step: 1000 },
+        { id: 'down', label: 'Down payment', default: 100000, step: 1000 },
+        { id: 'term', label: 'Amortization (years)', default: 25, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 4.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
@@ -99,9 +99,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-GB',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 350000, step: 1000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 70000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Price', default: 350000, step: 1000 },
+        { id: 'down', label: 'Deposit', default: 70000, step: 1000 },
+        { id: 'term', label: 'Term (years)', default: 25, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 3.5, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
@@ -129,9 +129,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-AU',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 600000, step: 1000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 120000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Term (years)', default: 30, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Price', default: 600000, step: 1000 },
+        { id: 'down', label: 'Deposit', default: 120000, step: 1000 },
+        { id: 'term', label: 'Term (years)', default: 30, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 5.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
@@ -159,9 +159,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 300000, step: 1000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Deposit', default: 60000, step: 1000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Term (years)', default: 25, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Price', default: 300000, step: 1000 },
+        { id: 'down', label: 'Deposit', default: 60000, step: 1000 },
+        { id: 'term', label: 'Term (years)', default: 25, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 3.8, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
@@ -190,9 +190,9 @@ export const schemas: Record<CountryCode, CountrySchema> = {
     locale: 'en-IN',
     fields: {
       basics: [
-        { id: 'price', label: 'Price', default: 5000000, step: 10000, tooltip: 'Purchase price of the property.' },
-        { id: 'down', label: 'Down payment', default: 1000000, step: 10000, tooltip: 'Up-front partial payment that reduces the mortgage principal.' },
-        { id: 'term', label: 'Term (years)', default: 20, step: 1, tooltip: 'Number of years scheduled to repay the mortgage.' },
+        { id: 'price', label: 'Price', default: 5000000, step: 10000 },
+        { id: 'down', label: 'Down payment', default: 1000000, step: 10000 },
+        { id: 'term', label: 'Term (years)', default: 20, step: 1 },
         { id: 'rate', label: 'Rate (APR %)', default: 8.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [


### PR DESCRIPTION
## Summary
- show tooltip text for all mortgage inputs and hide the icon when no description is provided
- drop tooltips from country, currency, property price, down payment and loan term fields

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8eccf25588329875e473d4e70f871