### PR TITLE
Add click-activated tooltips to mortgage calculator

### DIFF
--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+
+interface TooltipProps {
+  text: string;
+}
+
+export default function Tooltip({ text }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, []);
+
+  return (
+    <span className="tooltip-wrapper" ref={ref}>
+      <span
+        className="tooltip-icon"
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen(o => !o)}
+        onKeyDown={e => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen(o => !o);
+          }
+        }}
+        aria-label={text}
+      >
+        ?
+      </span>
+      {open && <span className="tooltip-bubble">{text}</span>}
+    </span>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -82,7 +82,9 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .label-unit{display:block;margin-bottom:4px;font-weight:600;font-size:.85rem;color:var(--muted)}
 .label-tooltip{display:flex;align-items:center;gap:4px;margin-bottom:6px;font-weight:600}
 .label-tooltip label{margin:0}
-.tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:help}
+.tooltip-wrapper{position:relative;display:inline-block}
+.tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:pointer}
+.tooltip-bubble{position:absolute;top:100%;left:0;z-index:20;margin-top:4px;padding:6px 8px;border-radius:6px;background:var(--navy);color:var(--white);font-size:.75rem;max-width:200px;box-shadow:0 4px 8px rgba(0,0,0,.1)}
 .label-tooltip .tooltip-icon:hover{background:var(--primary)}
 
 .grid{display:grid;gap:16px}

--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import CalcShell from "../components/CalcShell";
+import Tooltip from "../components/Tooltip";
 import { schemas, CountryCode } from "@/lib/mortgage";
 
 const symbolMap: Record<string, string> = {
@@ -87,9 +88,7 @@ export default function MortgageClient() {
               <div key={f.id}>
                 <div className="label-tooltip">
                   <label htmlFor={f.id}>{label}</label>
-                  {f.tooltip && (
-                    <span className="tooltip-icon" title={f.tooltip} aria-label={f.tooltip}>?</span>
-                  )}
+                  {f.tooltip && <Tooltip text={f.tooltip} />}
                 </div>
                 <input
                   id={f.id}


### PR DESCRIPTION
## Summary
- add reusable Tooltip component with outside click handling
- replace mortgage form "title" hints with clickable Tooltip
- style tooltip wrapper and bubble

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8eeb548808329bc8bfe59f3ddf8df