### PR TITLE
Simplify strata fee label

### DIFF
--- a/app/mortgage/page.tsx
+++ b/app/mortgage/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
   description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees and upfront costs.',
-  keywords: ['mortgage calculator', 'home loan', 'amortization', 'down payment', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'condo fees', 'ground rent', 'stamp duty', 'CMHC insurance', 'LMI', 'notary fees', 'processing fee', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
+  keywords: ['mortgage calculator', 'home loan', 'amortization', 'down payment', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'body corporate fees', 'condo fees', 'ground rent', 'stamp duty', 'CMHC insurance', 'LMI', 'notary fees', 'processing fee', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
   alternates: { canonical: '/mortgage' },
   openGraph: {
     title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',

--- a/lib/mortgage.ts
+++ b/lib/mortgage.ts
@@ -135,7 +135,7 @@ export const schemas: Record<CountryCode, CountrySchema> = {
         { id: 'rate', label: 'Rate (APR %)', default: 5.0, step: 0.01, tooltip: 'Annual percentage rate, the yearly cost of borrowing.' },
       ],
       recurring: [
-        { id: 'strata', label: 'Strata/body-corp fees', default: 0, step: 10, tooltip: 'Contributions to a body corporate for shared property upkeep.' },
+        { id: 'strata', label: 'Strata fees', default: 0, step: 10, tooltip: 'Contributions to a body corporate for shared property upkeep.' },
         { id: 'ins', label: 'Insurance', default: 1000, step: 100, annual: true, tooltip: 'Insurance covering a private residence and its contents.' },
       ],
       upfront: [


### PR DESCRIPTION
## Summary
- Shorten Australian strata fee field label
- Add body corporate fees to mortgage page SEO keywords

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f309c0e4832993b908c94bdcfa3b