### PR TITLE
Expand tooltip width to prevent clipping

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,7 +84,7 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .label-tooltip label{margin:0;flex:1}
 .tooltip-wrapper{position:relative;display:inline-block}
 .tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:pointer}
-.tooltip-bubble{position:absolute;top:100%;left:0;z-index:20;margin-top:4px;padding:6px 8px;border-radius:6px;background:var(--navy);color:var(--white);font-size:.75rem;max-width:200px;box-shadow:0 4px 8px rgba(0,0,0,.1)}
+.tooltip-bubble{position:absolute;top:100%;left:0;z-index:20;margin-top:4px;padding:6px 8px;border-radius:6px;background:var(--navy);color:var(--white);font-size:.75rem;max-width:280px;box-shadow:0 4px 8px rgba(0,0,0,.1)}
 .label-tooltip .tooltip-icon:hover{background:var(--primary)}
 
 .grid{display:grid;gap:16px}


### PR DESCRIPTION
## Summary
- expand tooltip bubble max width so longer explanations aren't cut off

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8f4bfaf508329b201c0f4fbd27de0