### PR TITLE
fix: ensure tooltips appear above neighboring cards

### DIFF
--- a/app/components/CalcShell.css
+++ b/app/components/CalcShell.css
@@ -6,7 +6,6 @@
     color-mix(in oklab,var(--primary) 12%, var(--card)),
     var(--card));
   box-shadow: var(--shadow);
-  overflow: hidden;
 }
 
 .calc-shell::before {
@@ -14,6 +13,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+  border-radius: inherit;
   background:
     radial-gradient(120% 60% at 0% 0%, color-mix(in oklab,var(--primary) 20%, transparent), transparent),
     radial-gradient(120% 60% at 100% 100%, color-mix(in oklab,var(--primary) 20%, transparent), transparent);
@@ -22,7 +22,6 @@
 
 .calc-shell > * {
   position: relative;
-  z-index: 1;
 }
 
 .calc-shell .card {


### PR DESCRIPTION
## Summary
- allow tooltips in calculators to overlay adjacent cards by removing stacking context
- ensure CalcShell gradients respect rounded corners without using overflow hidden

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f80bcc008329a9cb55707fe8471a