### PR TITLE
Fix tooltip position on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -85,6 +85,7 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .tooltip-wrapper{position:relative;display:inline-block}
 .tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:pointer}
 .tooltip-bubble{position:absolute;top:100%;right:0;left:auto;z-index:20;margin-top:4px;padding:6px 8px;border-radius:6px;background:var(--navy);color:var(--white);font-size:.75rem;width:max-content;max-width:min(480px,calc(100vw - 2rem));box-shadow:0 4px 8px rgba(0,0,0,.1)}
+@media (max-width:600px){.tooltip-bubble{left:50%;right:auto;transform:translateX(-50%)}}
 
 .label-tooltip .tooltip-icon:hover{background:var(--primary)}
 


### PR DESCRIPTION
## Summary
- Center tooltip bubbles on small screens to keep content visible

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8faf343c48329a4f3e6e852efb443