### PR TITLE
Align mortgage inputs when labels wrap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,7 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .label-tooltip label{margin:0;flex:1}
 .tooltip-wrapper{position:relative;display:inline-block}
 .tooltip-icon{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;background:var(--muted);color:var(--white);font-size:.75rem;cursor:pointer}
+.form-field{display:flex;flex-direction:column;justify-content:space-between;height:100%}
 .tooltip-bubble{position:absolute;top:100%;right:0;left:auto;z-index:20;margin-top:4px;padding:6px 8px;border-radius:6px;background:var(--navy);color:var(--white);font-size:.75rem;width:max-content;max-width:min(480px,calc(100vw - 2rem));box-shadow:0 4px 8px rgba(0,0,0,.1)}
 @media (max-width:600px){.tooltip-bubble{left:50%;right:auto;transform:translateX(-50%);max-width:min(260px,calc(100vw - 2rem))}}
 

--- a/app/mortgage/MortgageClient.tsx
+++ b/app/mortgage/MortgageClient.tsx
@@ -85,7 +85,7 @@ export default function MortgageClient() {
               if (f.type !== 'percent') label += ` (${symbolMap[currency]})`;
             }
             return (
-              <div key={f.id}>
+              <div key={f.id} className="form-field">
                 <div className="label-tooltip">
                   <label htmlFor={f.id}>{label}</label>
                   {f.tooltip && <Tooltip text={f.tooltip} />}


### PR DESCRIPTION
## Summary
- add `.form-field` layout class so inputs align even when labels span multiple lines
- apply new class to mortgage calculator fields to prevent input misalignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8fe9355a083298f7b8e699576fcba