### PR TITLE
Replace hero tagline and right-align footer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -103,7 +103,7 @@ label{display:block;margin-bottom:6px;font-weight:600}
 .badge{display:inline-flex;gap:6px;align-items:center;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--white);color:var(--muted);font-weight:600}
 .form-section{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:20px;margin-top:20px}
 .section-title{margin:0 0 16px;font-size:1.1rem;font-weight:700;color:var(--navy)}
-.footer{border-top:1px solid var(--border);padding:28px;margin-top:52px;color:var(--muted);font-size:.95rem}
+.footer{border-top:1px solid var(--border);padding:28px;margin-top:52px;color:var(--muted);font-size:.95rem;text-align:right;display:flex;justify-content:flex-end}
 
 .small{color:var(--muted)}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 20px;border-radius:12px;font-weight:700;cursor:pointer;text-decoration:none;min-height:48px;border:1px solid transparent}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
 
 export const metadata: Metadata = {
   title: "QuickCalc — Calculators that just work",
-  description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
+  description: "Smart, clean calculators for everyday life. From mortgages to BMI—powered by free public APIs.",
   keywords: [
     "online calculators",
     "mortgage calculator",
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "QuickCalc — Calculators that just work",
-    description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
+    description: "Smart, clean calculators for everyday life. From mortgages to BMI—powered by free public APIs.",
     url: baseUrl,
     siteName: "QuickCalc",
     type: "website",
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "QuickCalc — Calculators that just work",
-    description: "Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.",
+    description: "Smart, clean calculators for everyday life. From mortgages to BMI—powered by free public APIs.",
     images: ["/logos/social-1200.png"],
     creator: "@quickcalc"
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
           />
         </div>
         <h1 className={outfit.className}>Calculators that just work</h1>
-        <p>Clean design, instant results, no clutter. From mortgages to BMI—powered by free public APIs.</p>
+        <p>Smart, clean calculators for everyday life.</p>
         <div className="hero-ctas">
           <Link href="/bmi" className="btn btn-primary">Open BMI Calculator</Link>
           <a


### PR DESCRIPTION
## Summary
- switch home hero sub-headline to "Smart, clean calculators for everyday life"
- update site metadata to match new tagline for better SEO
- right-align footer text and link

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9037a19e08329b35da55358c18bfc