### PR TITLE
Add cookie consent banner and remove external links

### DIFF
--- a/app/components/ConsentBanner.tsx
+++ b/app/components/ConsentBanner.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ConsentBanner() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('qc-consent');
+    if (!consent) {
+      setShow(true);
+    } else if (consent === 'granted') {
+      (window as any).gtag?.('consent', 'update', {
+        ad_storage: 'granted',
+        analytics_storage: 'granted',
+        functionality_storage: 'granted',
+        personalization_storage: 'granted'
+      });
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('qc-consent', 'granted');
+    (window as any).gtag?.('consent', 'update', {
+      ad_storage: 'granted',
+      analytics_storage: 'granted',
+      functionality_storage: 'granted',
+      personalization_storage: 'granted'
+    });
+    setShow(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem('qc-consent', 'denied');
+    setShow(false);
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="consent-banner">
+      <span>We use cookies for analytics. Do you accept?</span>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button className="btn btn-primary" onClick={accept}>Accept</button>
+        <button className="btn btn-ghost" onClick={decline}>Decline</button>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,3 +153,19 @@ label{display:block;margin-bottom:6px;font-weight:600}
   .links a{width:100%;}
 }
 
+.consent-banner{
+  position:fixed;
+  left:0;
+  right:0;
+  bottom:0;
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  justify-content:center;
+  align-items:center;
+  padding:16px;
+  background:var(--navy);
+  color:var(--white);
+  z-index:100;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import "./globals.css";
 import Header from "./components/Header";
 import { Analytics } from "@vercel/analytics/next";
+import ConsentBanner from "./components/ConsentBanner";
 
 const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
 const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
@@ -64,10 +65,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('consent', 'default', {
-              ad_storage: 'granted',
-              analytics_storage: 'granted',
-              functionality_storage: 'granted',
-              personalization_storage: 'granted',
+              ad_storage: 'denied',
+              analytics_storage: 'denied',
+              functionality_storage: 'denied',
+              personalization_storage: 'denied',
               security_storage: 'granted'
             });
             gtag('js', new Date());
@@ -89,17 +90,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <main className="container" style={{ paddingTop: 24 }}>{children}</main>
         <footer className="footer container">
           <div>
-            © {new Date().getFullYear()} QuickCalc • Fast, private, no sign-up •
-            <a
-              href="https://utilixy.com"
-              target="_blank"
-              rel="noopener"
-              title="Utilixy – Free PDF & image conversion tools"
-            >
-              Utilixy
-            </a>
+            © {new Date().getFullYear()} QuickCalc • Fast, private, no sign-up
           </div>
         </footer>
+        <ConsentBanner />
         <Analytics />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
 export const metadata: Metadata = {
   title: "QuickCalc – Free Online Calculators",
   description:
-    "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations. Need PDF or image conversions? Try Utilixy.",
+    "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations.",
   keywords: [
     "free online calculators",
     "mortgage calculator",
@@ -17,16 +17,13 @@ export const metadata: Metadata = {
     "age calculator",
     "tip calculator",
     "date difference calculator",
-    "business days calculator",
-    "pdf converter",
-    "image converter",
-    "utilixy"
+    "business days calculator"
   ],
   alternates: { canonical: '/' },
   openGraph: {
     title: "QuickCalc – Free Online Calculators",
     description:
-      "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations. Need PDF or image conversions? Try Utilixy.",
+      "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations.",
     url: baseUrl,
     images: [
       {
@@ -110,15 +107,6 @@ export default function Home() {
         <p>Smart, clean calculators for everyday life.</p>
         <div className="hero-ctas">
           <Link href="/bmi" className="btn btn-primary">Open BMI Calculator</Link>
-          <a
-            href="https://utilixy.com"
-            target="_blank"
-            rel="noopener"
-            className="btn btn-ghost"
-            title="Utilixy – Free PDF, image, and data converters"
-          >
-            Visit utilixy.com
-          </a>
         </div>
       </section>
       <section id="calc-grid" className="grid" style={{gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))"}}>
@@ -139,19 +127,6 @@ export default function Home() {
           </Link>
         ))}
       </section>
-      <p className="small" style={{ textAlign: "center", marginTop: 32 }}>
-        Need PDF or image conversions? Try{' '}
-        <a
-          href="https://utilixy.com"
-          target="_blank"
-          rel="noopener"
-          className="fancy-link"
-          title="Utilixy – Free PDF, image, and data converters"
-        >
-          Utilixy
-        </a>
-        .
-      </p>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add cookie consent banner to control analytics cookies
- default Google Analytics consent to denied until users accept
- remove Utilixy mentions and links for cleaner SEO

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aafa068e3c832980d8e300574af17c