### PR TITLE
Resolve duplicate canonical tags for calculators

### DIFF
--- a/app/age/metadata.ts
+++ b/app/age/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Age Calculator — How Old Am I?',
   description: 'Determine your exact age in years, months, days and total days lived using our accurate age calculator.',
   keywords: ['age calculator', 'how old am I', 'date of birth', 'age in days'],
-  alternates: { canonical: '/age' },
+  alternates: { canonical: canonical('/age') },
   openGraph: {
     title: 'Age Calculator — How Old Am I?',
     description: 'Determine your exact age in years, months, days and total days lived using our accurate age calculator.',
+    url: canonical('/age'),
     images: [{ url: '/images/age.jpg', width: 1200, height: 630, alt: 'Age calculator' }]
   }
 };

--- a/app/age/page.tsx
+++ b/app/age/page.tsx
@@ -1,29 +1,16 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import AgeClient from './AgeClient';
 import AgeGuide from './AgeGuide';
-
-export const metadata: Metadata = {
-  title: 'Age Calculator — Exact Age in Years, Months, and Days',
-  description: 'Calculate your precise age and total days lived from your birth date.',
-  keywords: ['age calculator','how old am I','date of birth calculator','days lived','exact age'],
-  alternates: { canonical: '/age' },
-  openGraph: {
-    title: 'Age Calculator — Exact Age in Years, Months, and Days',
-    description: 'Calculate your precise age and total days lived from your birth date.',
-    images: [{ url: '/images/age.jpg', width: 1200, height: 630, alt: 'Age calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Age Calculator',
     applicationCategory: 'UtilityApplication',
     operatingSystem: 'Any',
-    url: `${base}/age`
+    url: canonical('/age')
   };
   return (
     <>

--- a/app/bmi/metadata.ts
+++ b/app/bmi/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'BMI & Body Fat Calculator — Body Mass Index',
   description: 'Compute your Body Mass Index with our interactive and stylish calculator, estimate body fat percentage and learn about BMI categories, formula and limitations.',
   keywords: ['BMI', 'Body Mass Index', 'body fat', 'BMI calculator', 'body fat calculator', 'health'],
-  alternates: { canonical: '/bmi' },
+  alternates: { canonical: canonical('/bmi') },
   openGraph: {
     title: 'BMI & Body Fat Calculator — Body Mass Index',
     description: 'Compute your Body Mass Index with our interactive and stylish calculator, estimate body fat percentage and learn about BMI categories, formula and limitations.',
+    url: canonical('/bmi'),
     images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator' }],
   },
 };

--- a/app/bmi/page.tsx
+++ b/app/bmi/page.tsx
@@ -1,28 +1,15 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import BmiClient from './BmiClient';
-
-export const metadata: Metadata = {
-  title: 'BMI Calculator — Body Mass Index & Fat Percentage',
-  description: 'Compute your BMI and body fat using metric or imperial units.',
-  keywords: ['bmi calculator','body mass index','body fat','metric bmi','imperial bmi'],
-  alternates: { canonical: '/bmi' },
-  openGraph: {
-    title: 'BMI Calculator — Body Mass Index & Fat Percentage',
-    description: 'Compute your BMI and body fat using metric or imperial units.',
-    images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'BMI Calculator',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
-    url: `${base}/bmi`
+    url: canonical('/bmi')
   };
   return (
     <>

--- a/app/business-days/metadata.ts
+++ b/app/business-days/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Business Days Calculator — Workday Counter',
   description: 'Count business days between dates excluding weekends and public holidays for multiple countries.',
   keywords: ['business days calculator', 'working days', 'workday calculator', 'public holidays', 'business day counter'],
-  alternates: { canonical: '/business-days' },
+  alternates: { canonical: canonical('/business-days') },
   openGraph: {
     title: 'Business Days Calculator — Workday Counter',
     description: 'Count business days between dates excluding weekends and public holidays for multiple countries.',
+    url: canonical('/business-days'),
     images: [{ url: '/images/business.jpg', width: 1200, height: 630, alt: 'Business days calculator' }]
   }
 };

--- a/app/business-days/page.tsx
+++ b/app/business-days/page.tsx
@@ -1,28 +1,15 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import BizDaysClient from './BizDaysClient';
-
-export const metadata: Metadata = {
-  title: 'Business Days Calculator — Workdays Between Dates',
-  description: 'Count working days between two dates excluding weekends and public holidays.',
-  keywords: ['business days calculator','workdays calculator','weekdays calculator','business day count','holiday calculator'],
-  alternates: { canonical: '/business-days' },
-  openGraph: {
-    title: 'Business Days Calculator — Workdays Between Dates',
-    description: 'Count working days between two dates excluding weekends and public holidays.',
-    images: [{ url: '/images/business.jpg', width: 1200, height: 630, alt: 'Business days calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Business Days Calculator',
     applicationCategory: 'BusinessApplication',
     operatingSystem: 'Any',
-    url: `${base}/business-days`
+    url: canonical('/business-days')
   };
   return (
     <>

--- a/app/compound-interest/page.tsx
+++ b/app/compound-interest/page.tsx
@@ -2,15 +2,17 @@ import type { Metadata } from 'next';
 import Script from 'next/script';
 import CompoundClient from './CompoundClient';
 import CompoundGuide from './CompoundGuide';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Compound Interest Calculator — Investment Growth Over Time',
   description: 'Calculate compound interest with optional periodic contributions to see how savings grow.',
   keywords: ['compound interest calculator','investment calculator','savings growth','future value','interest compounding'],
-  alternates: { canonical: '/compound-interest' },
+  alternates: { canonical: canonical('/compound-interest') },
   openGraph: {
     title: 'Compound Interest Calculator — Investment Growth Over Time',
     description: 'Calculate compound interest with optional periodic contributions to see how savings grow.',
+    url: canonical('/compound-interest'),
     images: [
       {
         url: 'https://upload.wikimedia.org/wikipedia/commons/b/b9/Compound_interest.svg',
@@ -23,14 +25,13 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Compound Interest Calculator',
     applicationCategory: 'FinanceApplication',
     operatingSystem: 'Any',
-    url: `${base}/compound-interest`
+    url: canonical('/compound-interest')
   };
   return (
     <>

--- a/app/date-diff/metadata.ts
+++ b/app/date-diff/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Date Difference Calculator — Days Between Dates',
   description: 'Calculate days and weeks between two dates instantly.',
   keywords: ['date difference', 'days between dates', 'date calculator', 'duration calculator'],
-  alternates: { canonical: '/date-diff' },
+  alternates: { canonical: canonical('/date-diff') },
   openGraph: {
     title: 'Date Difference Calculator — Days Between Dates',
     description: 'Calculate days and weeks between two dates instantly.',
+    url: canonical('/date-diff'),
     images: [{ url: '/images/date.jpg', width: 1200, height: 630, alt: 'Date difference calculator' }]
   }
 };

--- a/app/date-diff/page.tsx
+++ b/app/date-diff/page.tsx
@@ -1,28 +1,15 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import DateDiffClient from './DateDiffClient';
-
-export const metadata: Metadata = {
-  title: 'Date Difference Calculator — Days & Weeks Between Dates',
-  description: 'Find the number of days and weeks between two dates instantly.',
-  keywords: ['date difference calculator','days between dates','weeks between dates','duration calculator','time between dates'],
-  alternates: { canonical: '/date-diff' },
-  openGraph: {
-    title: 'Date Difference Calculator — Days & Weeks Between Dates',
-    description: 'Find the number of days and weeks between two dates instantly.',
-    images: [{ url: '/images/date.jpg', width: 1200, height: 630, alt: 'Date difference calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Date Difference Calculator',
     applicationCategory: 'UtilityApplication',
     operatingSystem: 'Any',
-    url: `${base}/date-diff`
+    url: canonical('/date-diff')
   };
   return (
     <>

--- a/app/loan/metadata.ts
+++ b/app/loan/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Loan Calculator — Payment Schedule & Interest',
   description: 'Plan your personal or auto loan with monthly payment, total interest and payoff estimates.',
   keywords: ['loan calculator', 'monthly payment', 'interest calculator', 'personal loan', 'auto loan'],
-  alternates: { canonical: '/loan' },
+  alternates: { canonical: canonical('/loan') },
   openGraph: {
     title: 'Loan Calculator — Payment Schedule & Interest',
     description: 'Plan your personal or auto loan with monthly payment, total interest and payoff estimates.',
+    url: canonical('/loan'),
     images: [{ url: '/images/loan.jpg', width: 1200, height: 630, alt: 'Loan calculator' }]
   }
 };

--- a/app/loan/page.tsx
+++ b/app/loan/page.tsx
@@ -1,29 +1,16 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import LoanClient from './LoanClient';
 import LoanGuide from './LoanGuide';
-
-export const metadata: Metadata = {
-  title: 'Loan Calculator — Monthly Payment & Interest Estimator',
-  description: 'Calculate loan repayments, total interest and payoff costs for personal or auto loans.',
-  keywords: ['loan calculator','payment calculator','interest calculator','amortization','personal loan','auto loan'],
-  alternates: { canonical: '/loan' },
-  openGraph: {
-    title: 'Loan Calculator — Monthly Payment & Interest Estimator',
-    description: 'Calculate loan repayments, total interest and payoff costs for personal or auto loans.',
-    images: [{ url: '/images/loan.jpg', width: 1200, height: 630, alt: 'Loan calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Loan Calculator',
     applicationCategory: 'FinanceApplication',
     operatingSystem: 'Any',
-    url: `${base}/loan`
+    url: canonical('/loan')
   };
   return (
     <>

--- a/app/mortgage/page.tsx
+++ b/app/mortgage/page.tsx
@@ -2,15 +2,17 @@ import MortgageClient from './MortgageClient';
 import MortgageFAQ from './MortgageFAQ';
 import Script from 'next/script';
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
   description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees, upfront costs and a comprehensive mortgage FAQ.',
   keywords: ['mortgage calculator', 'home loan', 'amortization', 'down payment', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'body corporate fees', 'condo fees', 'ground rent', 'stamp duty', 'CMHC insurance', 'LMI', 'notary fees', 'processing fee', 'mortgage faq', 'home loan faq', 'mortgage questions', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
-  alternates: { canonical: '/mortgage' },
+  alternates: { canonical: canonical('/mortgage') },
   openGraph: {
     title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
     description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees, upfront costs and a comprehensive mortgage FAQ.',
+    url: canonical('/mortgage'),
     images: [{ url: '/images/mortgage.jpg', width: 1200, height: 630, alt: 'Mortgage calculator' }]
   }
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Outfit } from "next/font/google";
 import type { Metadata } from "next";
-
-const baseUrl = process.env.SITE_URL ?? "https://quickcalc.me";
+import { canonical } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "QuickCalc – Free Online Calculators",
@@ -19,12 +18,12 @@ export const metadata: Metadata = {
     "date difference calculator",
     "business days calculator"
   ],
-  alternates: { canonical: '/' },
+  alternates: { canonical: canonical('/') },
   openGraph: {
     title: "QuickCalc – Free Online Calculators",
     description:
       "Instant answers for mortgage, loan, BMI, age, date difference, tip and business day calculations.",
-    url: baseUrl,
+    url: canonical('/'),
     images: [
       {
         url: "/logos/social-1200.png",

--- a/app/tip/metadata.ts
+++ b/app/tip/metadata.ts
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Tip Calculator — Split Bills & Tips',
   description: 'Quickly split restaurant bills and tips per person with adjustable percentages.',
   keywords: ['tip calculator', 'bill splitter', 'restaurant tip', 'split bill', 'gratuity'],
-  alternates: { canonical: '/tip' },
+  alternates: { canonical: canonical('/tip') },
   openGraph: {
     title: 'Tip Calculator — Split Bills & Tips',
     description: 'Quickly split restaurant bills and tips per person with adjustable percentages.',
+    url: canonical('/tip'),
     images: [{ url: '/images/tips.jpg', width: 1200, height: 630, alt: 'Tip calculator' }]
   }
 };

--- a/app/tip/page.tsx
+++ b/app/tip/page.tsx
@@ -1,28 +1,15 @@
-import type { Metadata } from 'next';
 import Script from 'next/script';
 import TipClient from './TipClient';
-
-export const metadata: Metadata = {
-  title: 'Tip Calculator — Split Bills & Tips Fast',
-  description: 'Figure out restaurant tips, totals and per-person shares instantly.',
-  keywords: ['tip calculator','bill splitter','gratuity calculator','restaurant tip','split bill'],
-  alternates: { canonical: '/tip' },
-  openGraph: {
-    title: 'Tip Calculator — Split Bills & Tips Fast',
-    description: 'Figure out restaurant tips, totals and per-person shares instantly.',
-    images: [{ url: '/images/tips.jpg', width: 1200, height: 630, alt: 'Tip calculator' }]
-  }
-};
+import { canonical } from '@/lib/seo';
 
 export default function Page() {
-  const base = process.env.SITE_URL ?? 'https://quickcalc.me';
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Tip Calculator',
     applicationCategory: 'FinanceApplication',
     operatingSystem: 'Any',
-    url: `${base}/tip`
+    url: canonical('/tip')
   };
   return (
     <>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,5 @@
+export const baseUrl = process.env.SITE_URL ?? 'https://quickcalc.me';
+
+export function canonical(path: string): string {
+  return new URL(path, baseUrl).toString();
+}


### PR DESCRIPTION
## Summary
- centralize canonical URL helper
- ensure each calculator uses absolute canonical and Open Graph URLs
- remove duplicate page-level metadata exports

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e7a026c8329b7ce04600da50c1e