### PR TITLE
Expand content with FAQ and guides pages

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,7 +13,9 @@ const nav = [
   { href: "/date-diff", label: "Date Diff" },
   { href: "/tip", label: "Tip" },
   { href: "/business-days", label: "Business Days" },
-  { href: "/compound-interest", label: "Compound" }
+  { href: "/compound-interest", label: "Compound" },
+  { href: "/guides", label: "Guides" },
+  { href: "/faq", label: "FAQ" }
 ];
 
 export default function Header(){

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,78 @@
+import Script from 'next/script';
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
+
+export const metadata: Metadata = {
+  title: 'QuickCalc FAQs – Answers to Common Questions',
+  description: 'Find answers about QuickCalc pricing, accuracy, privacy and device support.',
+  keywords: [
+    'quickcalc faq',
+    'calculator help',
+    'is quickcalc free',
+    'calculator accuracy',
+    'privacy'
+  ],
+  alternates: { canonical: canonical('/faq') },
+  openGraph: {
+    title: 'QuickCalc FAQs – Answers to Common Questions',
+    description: 'Find answers about QuickCalc pricing, accuracy, privacy and device support.',
+    url: canonical('/faq'),
+    images: [
+      { url: '/logos/social-1200.png', width: 1200, height: 1200, alt: 'QuickCalc logo' }
+    ]
+  }
+};
+
+const faqs = [
+  {
+    question: 'Is QuickCalc free to use?',
+    answer: 'Yes, all calculators on QuickCalc are completely free with no sign-up required.'
+  },
+  {
+    question: 'Are your calculators accurate?',
+    answer:
+      'Our tools use well-known formulas and are tested against trusted references, but results should be verified for critical decisions.'
+  },
+  {
+    question: 'Do you store my data?',
+    answer: 'No personal data is stored. All calculations happen in your browser for privacy.'
+  },
+  {
+    question: 'Can I use QuickCalc on mobile?',
+    answer: 'Absolutely. The site is fully responsive and works on phones, tablets and desktops.'
+  },
+  {
+    question: 'How can I report a problem or suggest a calculator?',
+    answer:
+      'Reach out via the project issue tracker on GitHub or contact us at support@quickcalc.me.'
+  }
+];
+
+export default function Page() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map(f => ({
+      '@type': 'Question',
+      name: f.question,
+      acceptedAnswer: { '@type': 'Answer', text: f.answer }
+    }))
+  };
+
+  return (
+    <>
+      <Script id="schema-faq" type="application/ld+json" strategy="afterInteractive">
+        {JSON.stringify(jsonLd)}
+      </Script>
+      <section className="card faq">
+        <h1>Frequently Asked Questions</h1>
+        {faqs.map(f => (
+          <div key={f.question}>
+            <h3>{f.question}</h3>
+            <p>{f.answer}</p>
+          </div>
+        ))}
+      </section>
+    </>
+  );
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/seo';
+
+export const metadata: Metadata = {
+  title: 'QuickCalc Guides – Learn the Math Behind the Answers',
+  description:
+    'In-depth guides explaining how our calculators work and the formulas they use.',
+  keywords: [
+    'calculator guides',
+    'mortgage guide',
+    'loan guide',
+    'age calculator help',
+    'compound interest guide'
+  ],
+  alternates: { canonical: canonical('/guides') },
+  openGraph: {
+    title: 'QuickCalc Guides – Learn the Math Behind the Answers',
+    description:
+      'In-depth guides explaining how our calculators work and the formulas they use.',
+    url: canonical('/guides'),
+    images: [
+      { url: '/logos/social-1200.png', width: 1200, height: 1200, alt: 'QuickCalc logo' }
+    ]
+  }
+};
+
+const guides = [
+  {
+    href: '/loan',
+    title: 'Loan Calculator Guide',
+    desc: 'Understand amortization and payment schedules.'
+  },
+  {
+    href: '/age',
+    title: 'Age Calculator Guide',
+    desc: 'See how we compute exact age in years, months and days.'
+  },
+  {
+    href: '/compound-interest',
+    title: 'Compound Interest Guide',
+    desc: 'Learn the formula behind growing investments.'
+  }
+];
+
+export default function Page() {
+  return (
+    <section className="card" style={{ marginTop: 24 }}>
+      <h1>Calculator Guides</h1>
+      <p>
+        Each QuickCalc tool comes with an explanation so you know what the numbers mean.
+        Start learning:
+      </p>
+      <ul>
+        {guides.map(g => (
+          <li key={g.href} style={{ marginTop: 12 }}>
+            <Link className="fancy-link" href={g.href}>{g.title}</Link> – {g.desc}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,9 @@ export const metadata: Metadata = {
     "age calculator",
     "tip calculator",
     "date difference",
-    "business days calculator"
+    "business days calculator",
+    "calculator guides",
+    "calculator faq"
   ],
   metadataBase: new URL(baseUrl),
   robots: { index: true, follow: true },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,9 @@ export const metadata: Metadata = {
     "age calculator",
     "tip calculator",
     "date difference calculator",
-    "business days calculator"
+    "business days calculator",
+    "calculator guides",
+    "calculator faq"
   ],
   alternates: { canonical: canonical('/') },
   openGraph: {
@@ -125,6 +127,24 @@ export default function Home() {
 
           </Link>
         ))}
+      </section>
+      <section className="card" style={{ marginTop: 40 }}>
+        <h2>About QuickCalc</h2>
+        <p>
+          QuickCalc offers a growing collection of free online calculators designed for everyday use.
+          Each tool runs instantly in your browser, prioritizing privacy with no sign‑ups or data storage.
+        </p>
+        <p>
+          Looking to understand the math behind the numbers? Browse our
+          {" "}
+          <Link href="/guides" className="fancy-link">calculator guides</Link>
+          {" "}
+          or check the
+          {" "}
+          <Link href="/faq" className="fancy-link">FAQ</Link>
+          {" "}
+          for quick answers.
+        </p>
       </section>
     </>
   );

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,7 +11,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/date-diff",
     "/tip",
     "/business-days",
-    "/compound-interest"
+    "/compound-interest",
+    "/guides",
+    "/faq"
   ];
   return routes.map((r) => ({
     url: `${base}${r}`,


### PR DESCRIPTION
## Summary
- extend homepage with About section and links to new FAQ and guides pages
- add dedicated FAQ page with structured FAQ schema
- add guides page listing available calculator guides and update navigation, sitemap and metadata for SEO

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6e6bf19bc8329ae0611e36c44233a