### PR TITLE
feat: redesign calculators with visual dashboards

### DIFF
--- a/app/age/AgeClient.tsx
+++ b/app/age/AgeClient.tsx
@@ -1,6 +1,11 @@
 "use client";
 import { useMemo, useState } from "react";
+import { differenceInDays, differenceInWeeks, differenceInMonths, addYears } from "date-fns";
 import CalcShell from "../components/CalcShell";
+import AgeDial from "./AgeDial";
+import "./styles.css";
+
+const LIFE_EXPECTANCY_YEARS = 82;
 
 function diffYMD(from: Date, to: Date){
   let y = to.getFullYear() - from.getFullYear();
@@ -11,23 +16,109 @@ function diffYMD(from: Date, to: Date){
   return { y, m, d };
 }
 
+function nextBirthday(from: Date, now: Date){
+  const candidate = new Date(now.getFullYear(), from.getMonth(), from.getDate());
+  if (candidate < now) {
+    return new Date(now.getFullYear() + 1, from.getMonth(), from.getDate());
+  }
+  return candidate;
+}
+
+function clamp(value: number, min: number, max: number){
+  return Math.min(max, Math.max(min, value));
+}
+
 export default function AgeClient(){
   const [dob, setDob] = useState<string>(()=> new Date().toISOString().slice(0,10));
+  const birthDate = useMemo(() => new Date(dob), [dob]);
+
   const res = useMemo(()=>{
-    const from = new Date(dob); const now = new Date();
-    if (isNaN(+from)) return null;
+    const from = birthDate;
+    const now = new Date();
+    if (Number.isNaN(+from)) return null;
+
     const ymd = diffYMD(from, now);
-    const days = Math.floor((now.getTime() - from.getTime()) / 86400000);
-    return { ymd, days };
-  }, [dob]);
+    const daysLived = differenceInDays(now, from);
+    const weeksLived = differenceInWeeks(now, from);
+    const monthsLived = differenceInMonths(now, from);
+    const ageFraction = ymd.y + ymd.m / 12 + ymd.d / 365.25;
+    const expectancyProgress = clamp(ageFraction / LIFE_EXPECTANCY_YEARS, 0, 1);
+
+    const next = nextBirthday(from, now);
+    const daysToNext = Math.max(0, differenceInDays(next, now));
+    const milestone40 = addYears(from, 40);
+    const milestone65 = addYears(from, 65);
+
+    return {
+      ymd,
+      daysLived,
+      weeksLived,
+      monthsLived,
+      expectancyProgress,
+      nextBirthday: next,
+      daysToNext,
+      milestone40,
+      milestone65,
+      ageFraction
+    };
+  }, [birthDate]);
 
   return (
-    <CalcShell title="Age Calculator" subtitle="Exact age in years, months, and days." result={
-      res ? (<>
-        <div className="kpi"><span>Age</span><span>{res.ymd.y}y {res.ymd.m}m {res.ymd.d}d</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Days lived</span><span>{res.days.toLocaleString()}</span></div>
-      </>) : (<div className="kpi"><span>Age</span><span>—</span></div>)
+    <CalcShell title="Age Calculator" subtitle="Exact age with a live countdown to your next birthday." result={
+      res ? (
+        <div className="age-result">
+          <AgeDial
+            years={res.ymd.y}
+            months={res.ymd.m}
+            days={res.ymd.d}
+            percent={res.expectancyProgress}
+            expectancy={LIFE_EXPECTANCY_YEARS}
+          />
+          <div className="age-metrics">
+            <div className="metric-card">
+              <span className="metric-title">Days lived</span>
+              <span className="metric-value">{res.daysLived.toLocaleString()}</span>
+            </div>
+            <div className="metric-card">
+              <span className="metric-title">Weeks lived</span>
+              <span className="metric-value">{res.weeksLived.toLocaleString()}</span>
+            </div>
+            <div className="metric-card">
+              <span className="metric-title">Months lived</span>
+              <span className="metric-value">{res.monthsLived.toLocaleString()}</span>
+            </div>
+            <div className="metric-card highlight">
+              <span className="metric-title">Next birthday</span>
+              <span className="metric-value">{res.daysToNext} days</span>
+            </div>
+          </div>
+          <div className="age-timeline">
+            <div className="timeline-row">
+              <span>40 milestone</span>
+              <div className="timeline-bar">
+                <div
+                  className="timeline-fill"
+                  style={{ width: `${clamp(res.daysLived / differenceInDays(res.milestone40, birthDate) * 100, 0, 100)}%` }}
+                />
+              </div>
+              <span>{res.milestone40.getFullYear()}</span>
+            </div>
+            <div className="timeline-row">
+              <span>65 milestone</span>
+              <div className="timeline-bar">
+                <div
+                  className="timeline-fill"
+                  style={{ width: `${clamp(res.daysLived / differenceInDays(res.milestone65, birthDate) * 100, 0, 100)}%` }}
+                />
+              </div>
+              <span>{res.milestone65.getFullYear()}</span>
+            </div>
+          </div>
+          <p className="small">Life expectancy is set to {LIFE_EXPECTANCY_YEARS} years for visualisation.</p>
+        </div>
+      ) : (
+        <div className="kpi"><span>Age</span><span>—</span></div>
+      )
     }>
       <div className="grid">
         <div>

--- a/app/age/AgeDial.tsx
+++ b/app/age/AgeDial.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useMemo } from "react";
+
+interface AgeDialProps {
+  years: number;
+  months: number;
+  days: number;
+  percent: number;
+  expectancy: number;
+}
+
+const SIZE = 220;
+const STROKE = 18;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export default function AgeDial({ years, months, days, percent, expectancy }: AgeDialProps) {
+  const dash = useMemo(() => {
+    const clamped = Math.min(1, Math.max(0, percent));
+    const progress = CIRCUMFERENCE * clamped;
+    return `${progress} ${CIRCUMFERENCE - progress}`;
+  }, [percent]);
+
+  const ageLabel = `${years}y ${months}m ${days}d`;
+
+  return (
+    <div className="age-dial" aria-label={`Age dial showing ${ageLabel}`}>
+      <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} role="presentation">
+        <defs>
+          <linearGradient id="ageDialGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="var(--accent)" />
+            <stop offset="100%" stopColor="var(--primary)" />
+          </linearGradient>
+          <linearGradient id="ageDialTrack" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="rgba(15,31,58,0.08)" />
+            <stop offset="100%" stopColor="rgba(15,31,58,0.18)" />
+          </linearGradient>
+        </defs>
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          stroke="url(#ageDialTrack)"
+          strokeWidth={STROKE}
+          fill="none"
+        />
+        <circle
+          className="age-dial-progress"
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          stroke="url(#ageDialGradient)"
+          strokeWidth={STROKE}
+          strokeDasharray={dash}
+          strokeLinecap="round"
+          fill="none"
+          transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+        />
+      </svg>
+      <div className="age-dial-label">
+        <strong>{ageLabel}</strong>
+        <span>of {expectancy} yrs</span>
+      </div>
+    </div>
+  );
+}

--- a/app/age/AgeGuide.tsx
+++ b/app/age/AgeGuide.tsx
@@ -14,6 +14,11 @@ export default function AgeGuide() {
         To compute age by hand, subtract the birth date from today’s date. If the current month and
         day precede your birthday, borrow months and days to adjust the difference.
       </p>
+      <p>
+        The live countdown in the calculator uses the next occurrence of your birth date to show the
+        remaining days until you celebrate again. We assume a global life expectancy of 82 years to
+        visualise the dial—this can be compared against your own goals or national averages.
+      </p>
       <h3 style={{ marginTop: 24 }}>Why knowing your age matters</h3>
       <p>
         Exact age is often required for legal documents, health screenings and milestone planning

--- a/app/age/metadata.ts
+++ b/app/age/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'Age Calculator — How Old Am I?',
-  description: 'Determine your exact age in years, months, days and total days lived using our accurate age calculator.',
-  keywords: ['age calculator', 'how old am I', 'date of birth', 'age in days'],
+  title: 'Age Calculator — Countdown to Your Next Birthday',
+  description: 'Find your exact age in years, months and days, track time lived and see the live countdown to your next birthday.',
+  keywords: ['age calculator', 'how old am I', 'next birthday countdown', 'age in days'],
   alternates: { canonical: canonical('/age') },
   openGraph: {
-    title: 'Age Calculator — How Old Am I?',
-    description: 'Determine your exact age in years, months, days and total days lived using our accurate age calculator.',
+    title: 'Age Calculator — Countdown to Your Next Birthday',
+    description: 'Find your exact age in years, months and days, track time lived and see the live countdown to your next birthday.',
     url: canonical('/age'),
-    images: [{ url: '/images/age.jpg', width: 1200, height: 630, alt: 'Age calculator' }]
+    images: [{ url: '/images/age.jpg', width: 1200, height: 630, alt: 'Age calculator with countdown dial' }]
   }
 };

--- a/app/age/styles.css
+++ b/app/age/styles.css
@@ -1,0 +1,103 @@
+.age-result {
+  display: grid;
+  gap: 18px;
+}
+
+.age-dial {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.age-dial svg {
+  max-width: 240px;
+}
+
+.age-dial-label {
+  position: absolute;
+  text-align: center;
+  color: var(--navy);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 1rem;
+}
+
+.age-dial-label strong {
+  font-size: 1.35rem;
+}
+
+.age-metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.metric-card {
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--card) 85%, var(--primary) 15%);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.4);
+}
+
+.metric-card.highlight {
+  background: linear-gradient(135deg, color-mix(in oklab,var(--accent) 60%, var(--card)), var(--card));
+}
+
+.metric-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.metric-value {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.age-timeline {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 14px;
+  background: color-mix(in oklab,var(--primary) 8%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 18%, var(--border));
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.timeline-bar {
+  position: relative;
+  height: 8px;
+  background: rgba(15,31,58,0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.timeline-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+}
+
+@media (max-width: 640px) {
+  .age-dial svg {
+    max-width: 200px;
+  }
+}

--- a/app/api/business-days/route.ts
+++ b/app/api/business-days/route.ts
@@ -16,13 +16,29 @@ export async function GET(req: Request) {
   const holidays = await r.json();
   const set = new Set(holidays.map((h: any) => h.date));
 
-  let d = new Date(start); let businessDays = 0;
+  let d = new Date(start);
+  let businessDays = 0;
+  let weekendDays = 0;
+  let holidayDays = 0;
+  let calendarDays = 0;
+
   while (d <= end) {
-    const day = d.getDay(); // 0 Sun .. 6 Sat
+    calendarDays += 1;
+    const day = d.getDay();
     const iso = d.toISOString().slice(0,10);
-    if (day !== 0 && day !== 6 && !set.has(iso)) businessDays++;
+    const isWeekend = day === 0 || day === 6;
+    if (isWeekend) {
+      weekendDays += 1;
+    } else if (set.has(iso)) {
+      holidayDays += 1;
+    } else {
+      businessDays += 1;
+    }
     d.setDate(d.getDate() + 1);
   }
 
-  return NextResponse.json({ businessDays }, { headers: { "Cache-Control": "public, s-maxage=86400" } });
+  return NextResponse.json(
+    { businessDays, weekendDays, holidayDays, calendarDays },
+    { headers: { "Cache-Control": "public, s-maxage=86400" } }
+  );
 }

--- a/app/bmi/BmiClient.tsx
+++ b/app/bmi/BmiClient.tsx
@@ -7,87 +7,69 @@ import './styles.css';
 
 type Unit = 'metric' | 'us' | 'uk';
 
+type Gender = 'male' | 'female';
+
 const AGE_LIMITS = { min: 2, max: 120 };
 
-// acceptable human ranges (adjust if you want)
 const LIMITS = {
   metric: { cm: { min: 90, max: 250 }, kg: { min: 25, max: 250 } },
-  us:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, lb: { min: 60, max: 550 } },
-  uk:     { ft: { min: 3,  max: 7   }, in: { min: 0,  max: 11  }, st: { min: 4, max: 50 }, lb: { min: 0, max: 13 } }
+  us: { ft: { min: 3, max: 7 }, in: { min: 0, max: 11 }, lb: { min: 60, max: 550 } },
+  uk: { ft: { min: 3, max: 7 }, in: { min: 0, max: 11 }, st: { min: 4, max: 50 }, lb: { min: 0, max: 13 } }
 };
 
-
-// parse, strip leading zeros, clamp
 function sanitize(v: string, min: number, max: number) {
-  const cleaned = v.replace(/[^\d.]/g, '').replace(/^0+(?=\d)/, ''); // keep one decimal point
+  const cleaned = v.replace(/[^\d.]/g, '').replace(/^(\d*\.\d*).*/, '$1').replace(/^0+(?=\d)/, '');
   const n = parseFloat(cleaned);
   if (Number.isNaN(n)) return { n: NaN, raw: cleaned };
   return { n: Math.min(max, Math.max(min, n)), raw: cleaned };
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+const BMI_COPY: Record<string, string> = {
+  Underweight: 'Focus on nutrient-dense meals and strength training—professional guidance can help you gain safely.',
+  Normal: 'Maintain this healthy range with a balanced plate, good sleep and regular movement.',
+  Overweight: 'Small calorie adjustments and increased activity can help rebalance body fat over time.',
+  Obesity: 'Work with a health professional on a sustainable nutrition and activity plan tailored to you.'
+};
+
 export default function BmiClient() {
   const [unit, setUnit] = useState<Unit>('metric');
-
-  // demographics
   const [ageRaw, setAgeRaw] = useState('30');
-  const [gender, setGender] = useState<'male' | 'female'>('male');
-
-  // metric inputs
+  const [gender, setGender] = useState<Gender>('male');
   const [cmRaw, setCmRaw] = useState('175');
   const [kgRaw, setKgRaw] = useState('75');
-
-  // us / uk height inputs
   const [ftRaw, setFtRaw] = useState('5');
   const [inRaw, setInRaw] = useState('9');
-
-  // us weight
   const [lbRaw, setLbRaw] = useState('165');
-
-  // uk weight
   const [stRaw, setStRaw] = useState('11');
   const [stLbRaw, setStLbRaw] = useState('0');
 
   const ageData = useMemo(() => sanitize(ageRaw, AGE_LIMITS.min, AGE_LIMITS.max), [ageRaw]);
-  const ageError = !ageData.raw
-    ? 'Enter age.'
-    : Number.isNaN(ageData.n)
-    ? 'Invalid number.'
-    : '';
+  const ageError = !ageData.raw ? 'Enter age.' : Number.isNaN(ageData.n) ? 'Invalid number.' : '';
+
   const { cm, kg, ft, inch, lb, st, error } = useMemo(() => {
     if (unit === 'metric') {
       const sH = sanitize(cmRaw, LIMITS.metric.cm.min, LIMITS.metric.cm.max);
       const sW = sanitize(kgRaw, LIMITS.metric.kg.min, LIMITS.metric.kg.max);
-      const error =
-        !sH.raw || !sW.raw
-          ? 'Enter height and weight.'
-          : (Number.isNaN(sH.n) || Number.isNaN(sW.n))
-          ? 'Invalid number.'
-          : '';
-      return { cm: sH.n, kg: sW.n, ft: NaN, inch: NaN, lb: NaN, st: NaN, error };
-    } else if (unit === 'us') {
+      const err = !sH.raw || !sW.raw ? 'Enter height and weight.' : (Number.isNaN(sH.n) || Number.isNaN(sW.n)) ? 'Invalid number.' : '';
+      return { cm: sH.n, kg: sW.n, ft: NaN, inch: NaN, lb: NaN, st: NaN, error: err };
+    }
+    if (unit === 'us') {
       const sF = sanitize(ftRaw, LIMITS.us.ft.min, LIMITS.us.ft.max);
       const sI = sanitize(inRaw, LIMITS.us.in.min, LIMITS.us.in.max);
       const sL = sanitize(lbRaw, LIMITS.us.lb.min, LIMITS.us.lb.max);
-      const error =
-        !sF.raw || !sI.raw || !sL.raw
-          ? 'Enter height and weight.'
-          : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sL.n))
-          ? 'Invalid number.'
-          : '';
-      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sL.n, st: NaN, error };
-    } else {
-      const sF = sanitize(ftRaw, LIMITS.uk.ft.min, LIMITS.uk.ft.max);
-      const sI = sanitize(inRaw, LIMITS.uk.in.min, LIMITS.uk.in.max);
-      const sS = sanitize(stRaw, LIMITS.uk.st.min, LIMITS.uk.st.max);
-      const sP = sanitize(stLbRaw, LIMITS.uk.lb.min, LIMITS.uk.lb.max);
-      const error =
-        !sF.raw || !sI.raw || !sS.raw || !sP.raw
-          ? 'Enter height and weight.'
-          : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sS.n) || Number.isNaN(sP.n))
-          ? 'Invalid number.'
-          : '';
-      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sP.n, st: sS.n, error };
+      const err = !sF.raw || !sI.raw || !sL.raw ? 'Enter height and weight.' : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sL.n)) ? 'Invalid number.' : '';
+      return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sL.n, st: NaN, error: err };
     }
+    const sF = sanitize(ftRaw, LIMITS.uk.ft.min, LIMITS.uk.ft.max);
+    const sI = sanitize(inRaw, LIMITS.uk.in.min, LIMITS.uk.in.max);
+    const sS = sanitize(stRaw, LIMITS.uk.st.min, LIMITS.uk.st.max);
+    const sP = sanitize(stLbRaw, LIMITS.uk.lb.min, LIMITS.uk.lb.max);
+    const err = !sF.raw || !sI.raw || !sS.raw || !sP.raw ? 'Enter height and weight.' : (Number.isNaN(sF.n) || Number.isNaN(sI.n) || Number.isNaN(sS.n) || Number.isNaN(sP.n)) ? 'Invalid number.' : '';
+    return { cm: NaN, kg: NaN, ft: sF.n, inch: sI.n, lb: sP.n, st: sS.n, error: err };
   }, [unit, cmRaw, kgRaw, ftRaw, inRaw, lbRaw, stRaw, stLbRaw]);
 
   const bmi = useMemo(() => {
@@ -95,11 +77,10 @@ export default function BmiClient() {
     if (unit === 'metric') {
       const h = cm / 100;
       return +(kg / (h * h)).toFixed(1);
-    } else {
-      const totalIn = ft * 12 + inch;
-      const weightLb = unit === 'us' ? lb : st * 14 + lb;
-      return +((weightLb / (totalIn * totalIn)) * 703).toFixed(1);
     }
+    const totalIn = ft * 12 + inch;
+    const weightLb = unit === 'us' ? lb : st * 14 + lb;
+    return +((weightLb / (totalIn * totalIn)) * 703).toFixed(1);
   }, [unit, cm, kg, ft, inch, lb, st, error]);
 
   const cat = useMemo(() => {
@@ -116,21 +97,84 @@ export default function BmiClient() {
     return +(1.2 * bmi + 0.23 * ageData.n - 10.8 * g - 5.4).toFixed(1);
   }, [bmi, gender, ageData.n, ageError]);
 
+  const healthyWeightRange = useMemo(() => {
+    if (!Number.isFinite(bmi) || error) return null;
+    if (unit === 'metric') {
+      const meters = cm / 100;
+      const min = 18.5 * meters * meters;
+      const max = 24.9 * meters * meters;
+      return {
+        primary: `${min.toFixed(1)} – ${max.toFixed(1)} kg`,
+        secondary: `${(min * 2.20462).toFixed(1)} – ${(max * 2.20462).toFixed(1)} lb`
+      };
+    }
+    const totalIn = ft * 12 + inch;
+    const meters = totalIn * 0.0254;
+    const minKg = 18.5 * meters * meters;
+    const maxKg = 24.9 * meters * meters;
+    const minLb = minKg * 2.20462;
+    const maxLb = maxKg * 2.20462;
+    if (unit === 'us') {
+      return {
+        primary: `${minLb.toFixed(1)} – ${maxLb.toFixed(1)} lb`,
+        secondary: `${minKg.toFixed(1)} – ${maxKg.toFixed(1)} kg`
+      };
+    }
+    return {
+      primary: `${(minLb / 14).toFixed(1)} – ${(maxLb / 14).toFixed(1)} st`,
+      secondary: `${Math.round(minLb)} – ${Math.round(maxLb)} lb`
+    };
+  }, [unit, bmi, error, cm, ft, inch]);
+
+  const bmiAdvice = BMI_COPY[cat] ?? '';
+  const bmiPosition = useMemo(() => (Number.isFinite(bmi) ? clamp((bmi - 12) / (40 - 12), 0, 1) : 0), [bmi]);
+
   return (
     <>
       <CalcShell
           title="BMI Calculator"
           subtitle="Calculate your Body Mass Index and body fat percentage. Units: Metric, US or St/lb."
-          result={<>
-            <div className="kpi"><span>BMI</span><span>{Number.isFinite(bmi) ? bmi : '—'}</span></div>
-            <div style={{ height: 10 }} />
-            <div className="kpi"><span>Category</span><span>{Number.isFinite(bmi) ? cat : '—'}</span></div>
-            <div style={{ height: 10 }} />
-            <div className="kpi"><span>Body Fat %</span><span>{Number.isFinite(bfp) ? `${bfp}%` : '—'}</span></div>
-            <div style={{ height: 18 }} />
-            <BmiGauge value={Number.isFinite(bmi) ? bmi : 0} />
-            <p className="small">BMI and body fat % are general indicators only, not a diagnosis.</p>
-          </>}
+          result={
+            <div className="bmi-result">
+              <div className="bmi-stats">
+                <div className="bmi-kpi">
+                  <span className="label">BMI</span>
+                  <strong>{Number.isFinite(bmi) ? bmi : '—'}</strong>
+                </div>
+                <div className="bmi-kpi">
+                  <span className="label">Category</span>
+                  <strong>{Number.isFinite(bmi) ? cat : '—'}</strong>
+                </div>
+                <div className="bmi-kpi">
+                  <span className="label">Body fat %</span>
+                  <strong>{Number.isFinite(bfp) ? `${bfp}%` : '—'}</strong>
+                </div>
+              </div>
+              <div className="bmi-visual">
+                <BmiGauge value={Number.isFinite(bmi) ? bmi : 0} />
+                <div className="bmi-bar">
+                  <div className="bmi-bar-track">
+                    <div className="bmi-bar-fill" style={{ width: `${bmiPosition * 100}%` }} />
+                  </div>
+                  <div className="bmi-bar-labels">
+                    <span>12</span>
+                    <span>40</span>
+                  </div>
+                </div>
+              </div>
+              {healthyWeightRange && (
+                <div className="bmi-range">
+                  <div>
+                    <span className="label">Healthy weight range</span>
+                    <strong>{healthyWeightRange.primary}</strong>
+                  </div>
+                  <span className="alt">≈ {healthyWeightRange.secondary}</span>
+                </div>
+              )}
+              {bmiAdvice && <p className="bmi-advice">{bmiAdvice}</p>}
+              <p className="small">BMI and body fat % are screening tools only. Consult a health professional for personalised advice.</p>
+            </div>
+          }
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
             <div className="segment" role="tablist" aria-label="Units">
@@ -181,7 +225,8 @@ export default function BmiClient() {
                   value={cmRaw}
                   maxLength={5}
                   onChange={(e) => setCmRaw(e.target.value)}
-                  placeholder={`${LIMITS.metric.cm.min}–${LIMITS.metric.cm.max}`} />
+                  placeholder={`${LIMITS.metric.cm.min}–${LIMITS.metric.cm.max}`}
+                />
               </div>
               <div>
                 <label>Weight</label>
@@ -193,7 +238,8 @@ export default function BmiClient() {
                   value={kgRaw}
                   maxLength={6}
                   onChange={(e) => setKgRaw(e.target.value)}
-                  placeholder={`${LIMITS.metric.kg.min}–${LIMITS.metric.kg.max}`} />
+                  placeholder={`${LIMITS.metric.kg.min}–${LIMITS.metric.kg.max}`}
+                />
               </div>
               {error && <div className="help-error" style={{ gridColumn: '1 / -1' }}>{error}</div>}
             </div>
@@ -288,4 +334,3 @@ export default function BmiClient() {
     </>
   );
 }
-

--- a/app/bmi/metadata.ts
+++ b/app/bmi/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'BMI & Body Fat Calculator — Body Mass Index',
-  description: 'Compute your Body Mass Index with our interactive and stylish calculator, estimate body fat percentage and learn about BMI categories, formula and limitations.',
-  keywords: ['BMI', 'Body Mass Index', 'body fat', 'BMI calculator', 'body fat calculator', 'health'],
+  title: 'BMI & Body Fat Calculator — Healthy Weight Range Tool',
+  description: 'Compute your Body Mass Index, estimate body fat and see the ideal weight range for your height with our interactive BMI calculator.',
+  keywords: ['BMI calculator', 'body fat calculator', 'healthy weight range', 'body mass index'],
   alternates: { canonical: canonical('/bmi') },
   openGraph: {
-    title: 'BMI & Body Fat Calculator — Body Mass Index',
-    description: 'Compute your Body Mass Index with our interactive and stylish calculator, estimate body fat percentage and learn about BMI categories, formula and limitations.',
+    title: 'BMI & Body Fat Calculator — Healthy Weight Range Tool',
+    description: 'Compute your Body Mass Index, estimate body fat and see the ideal weight range for your height with our interactive BMI calculator.',
     url: canonical('/bmi'),
-    images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator' }],
+    images: [{ url: '/images/bmi.jpg', width: 1200, height: 630, alt: 'BMI calculator with gauge' }],
   },
 };

--- a/app/bmi/styles.css
+++ b/app/bmi/styles.css
@@ -1,9 +1,110 @@
+.bmi-result {
+  display: grid;
+  gap: 16px;
+}
+
+.bmi-stats {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.bmi-kpi {
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 12px 14px;
+  background: color-mix(in oklab,var(--primary) 12%, var(--card));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bmi-kpi .label {
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.bmi-kpi strong {
+  font-size: 1.4rem;
+  color: var(--navy);
+}
+
+.bmi-visual {
+  display: grid;
+  gap: 12px;
+}
+
+.bmi-bar {
+  display: grid;
+  gap: 4px;
+}
+
+.bmi-bar-track {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(15,31,58,0.12);
+  overflow: hidden;
+}
+
+.bmi-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+  border-radius: inherit;
+}
+
+.bmi-bar-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.bmi-range {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 14px;
+  padding: 12px 16px;
+  border: 1px solid color-mix(in oklab,var(--primary) 18%, var(--border));
+  background: color-mix(in oklab,var(--primary) 6%, var(--card));
+  flex-wrap: wrap;
+  gap: 4px 12px;
+}
+
+.bmi-range .label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.bmi-range strong {
+  display: block;
+  font-size: 1.1rem;
+  color: var(--navy);
+}
+
+.bmi-range .alt {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.bmi-advice {
+  border-left: 4px solid var(--accent);
+  padding-left: 12px;
+  font-weight: 600;
+  color: color-mix(in oklab,var(--navy) 80%, black 20%);
+}
+
 .bmi-info {
   background: color-mix(in oklab,var(--primary) 3%, var(--card));
   border-color: color-mix(in oklab,var(--primary) 18%, var(--border));
 }
 
-/* Ensure informational images scale on small screens */
 .bmi-info img {
   max-width: 100%;
   height: auto;

--- a/app/business-days/BizDaysClient.tsx
+++ b/app/business-days/BizDaysClient.tsx
@@ -1,32 +1,103 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import CalcShell from "../components/CalcShell";
+import "./styles.css";
+
+type Result = {
+  businessDays: number;
+  weekendDays: number;
+  holidayDays: number;
+  calendarDays: number;
+};
 
 export default function BizDaysClient(){
   const today = new Date().toISOString().slice(0,10);
   const [start, setStart] = useState(today);
   const [end, setEnd] = useState(today);
   const [country, setCountry] = useState("IE");
-  const [result, setResult] = useState<number | null>(null);
+  const [result, setResult] = useState<Result | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function calc(){
+    if (new Date(start) > new Date(end)) {
+      setError('End date must be after start date.');
+      setResult(null);
+      return;
+    }
+    setError(null);
     const url = `/api/business-days?country=${country}&start=${start}&end=${end}`;
     const r = await fetch(url);
     const j = await r.json();
-    setResult(j.businessDays);
+    if (r.ok) {
+      setResult(j as Result);
+      setError(null);
+    } else {
+      setError("Unable to reach holiday service. Try again later.");
+      setResult(null);
+    }
   }
 
-  useEffect(()=>{ calc().catch(()=>{}); }, [start, end, country]);
+  useEffect(()=>{
+    calc().catch(() => {
+      setError("Unable to reach holiday service. Try again later.");
+      setResult(null);
+    });
+  }, [start, end, country]);
+
+  const summary = useMemo(() => {
+    if (!result) return null;
+    const { businessDays, weekendDays, holidayDays, calendarDays } = result;
+    const workingShare = calendarDays > 0 ? businessDays / calendarDays : 0;
+    const weekendShare = calendarDays > 0 ? weekendDays / calendarDays : 0;
+    const holidayShare = calendarDays > 0 ? holidayDays / calendarDays : 0;
+    return {
+      businessDays,
+      weekendDays,
+      holidayDays,
+      calendarDays,
+      workingShare,
+      weekendShare,
+      holidayShare,
+      nonWorkDays: weekendDays + holidayDays
+    };
+  }, [result]);
 
   return (
     <CalcShell title="Business Days Calculator" subtitle="Working days between dates (excludes weekends & public holidays)." result={
-      <>
-        <div className="kpi"><span>Business days</span><span>{result ?? "—"}</span></div>
-        <p className="small">Powered by Nager.Date public holiday API.</p>
-      </>
+      <div className="biz-result">
+        <div className="biz-kpis">
+          <div className="biz-card">
+            <span className="label">Business days</span>
+            <strong>{summary ? summary.businessDays : "—"}</strong>
+          </div>
+          <div className="biz-card">
+            <span className="label">Non-working</span>
+            <strong>{summary ? summary.nonWorkDays : "—"}</strong>
+          </div>
+          <div className="biz-card">
+            <span className="label">Range length</span>
+            <strong>{summary ? summary.calendarDays : "—"}</strong>
+          </div>
+        </div>
+        {summary && (
+          <div className="biz-bar" aria-hidden="true">
+            <div className="segment weekend" style={{ width: `${summary.weekendShare * 100}%` }} title={`${summary.weekendDays} weekend days`} />
+            <div className="segment holiday" style={{ width: `${summary.holidayShare * 100}%` }} title={`${summary.holidayDays} public holidays`} />
+            <div className="segment work" style={{ width: `${summary.workingShare * 100}%` }} title={`${summary.businessDays} business days`} />
+          </div>
+        )}
+        {summary && (
+          <dl className="biz-legend">
+            <div><span className="dot weekend" /> <dt>Weekend</dt><dd>{summary.weekendDays}</dd></div>
+            <div><span className="dot holiday" /> <dt>Holidays</dt><dd>{summary.holidayDays}</dd></div>
+            <div><span className="dot work" /> <dt>Business</dt><dd>{summary.businessDays}</dd></div>
+          </dl>
+        )}
+        {error ? <p className="small" role="status">{error}</p> : <p className="small">Powered by the Nager.Date public holiday API.</p>}
+      </div>
     }>
       <div className="grid grid-2">
-        <div><label>Start date</label><input className="input" type="date" value={start} onChange={e=>setStart(e.target.value)} /></div>
+        <div><label>Start date</label><input className="input" type="date" value={start} onChange={e=>setStart(e.target.value)}/></div>
         <div><label>End date</label><input className="input" type="date" value={end} onChange={e=>setEnd(e.target.value)} /></div>
         <div>
           <label>Country</label>
@@ -39,6 +110,8 @@ export default function BizDaysClient(){
             <option value="ES">Spain</option>
             <option value="IT">Italy</option>
             <option value="NL">Netherlands</option>
+            <option value="PT">Portugal</option>
+            <option value="PL">Poland</option>
           </select>
         </div>
       </div>

--- a/app/business-days/BizDaysGuide.tsx
+++ b/app/business-days/BizDaysGuide.tsx
@@ -13,6 +13,11 @@ export default function BizDaysGuide() {
         List every day in the range, exclude Saturdays, Sundays and any holidays, then count the
         remaining days.
       </p>
+      <p>
+        The visual breakdown in the calculator mirrors this process by separating weekends,
+        public holidays and true business days so you can immediately see which parts of the
+        timeline remove working time.
+      </p>
       <h3 style={{ marginTop: 24 }}>Why it matters</h3>
       <p>
         Business day counts are vital for project timelines, shipping estimates and legal notice

--- a/app/business-days/metadata.ts
+++ b/app/business-days/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'Business Days Calculator — Workday Counter',
-  description: 'Count business days between dates excluding weekends and public holidays for multiple countries.',
-  keywords: ['business days calculator', 'working days', 'workday calculator', 'public holidays', 'business day counter'],
+  title: 'Business Days Calculator — Workday Timeline & Breakdown',
+  description: 'Count business days between dates, see weekend and public holiday breakdowns and support multiple countries.',
+  keywords: ['business days calculator', 'working days', 'workday calculator', 'public holidays', 'business day breakdown'],
   alternates: { canonical: canonical('/business-days') },
   openGraph: {
-    title: 'Business Days Calculator — Workday Counter',
-    description: 'Count business days between dates excluding weekends and public holidays for multiple countries.',
+    title: 'Business Days Calculator — Workday Timeline & Breakdown',
+    description: 'Count business days between dates, see weekend and public holiday breakdowns and support multiple countries.',
     url: canonical('/business-days'),
-    images: [{ url: '/images/business.jpg', width: 1200, height: 630, alt: 'Business days calculator' }]
+    images: [{ url: '/images/business.jpg', width: 1200, height: 630, alt: 'Business days calculator interface' }]
   }
 };

--- a/app/business-days/styles.css
+++ b/app/business-days/styles.css
@@ -1,0 +1,99 @@
+.biz-result {
+  display: grid;
+  gap: 16px;
+}
+
+.biz-kpis {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.biz-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 10%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 20%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.biz-card .label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.biz-card strong {
+  font-size: 1.4rem;
+  color: var(--navy);
+}
+
+.biz-bar {
+  display: flex;
+  overflow: hidden;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab,var(--primary) 16%, var(--border));
+  height: 14px;
+}
+
+.biz-bar .segment {
+  height: 100%;
+}
+
+.biz-bar .segment.weekend {
+  background: linear-gradient(90deg, rgba(15,31,58,.15), rgba(15,31,58,.25));
+}
+
+.biz-bar .segment.holiday {
+  background: linear-gradient(90deg, rgba(246,163,19,0.4), rgba(246,163,19,0.6));
+}
+
+.biz-bar .segment.work {
+  background: linear-gradient(90deg, rgba(34,197,94,0.6), rgba(34,197,94,0.9));
+}
+
+.biz-legend {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  margin: 0;
+}
+
+.biz-legend div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.biz-legend dt {
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.biz-legend dd {
+  margin: 0 0 0 auto;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-flex;
+}
+
+.dot.weekend {
+  background: rgba(15,31,58,0.35);
+}
+
+.dot.holiday {
+  background: var(--accent);
+}
+
+.dot.work {
+  background: #22c55e;
+}

--- a/app/compound-interest/CompoundClient.tsx
+++ b/app/compound-interest/CompoundClient.tsx
@@ -1,6 +1,20 @@
 'use client';
 import { useMemo, useState } from 'react';
 import CalcShell from '../components/CalcShell';
+import './styles.css';
+
+type GrowthPoint = { year: number; balance: number; contributions: number };
+
+function compoundBalance(principal: number, rate: number, times: number, years: number, contrib: number) {
+  const r = rate / 100;
+  const n = times;
+  if (r === 0) {
+    return principal + contrib * n * years;
+  }
+  const pow = Math.pow(1 + r / n, n * years);
+  const future = principal * pow + (contrib > 0 ? contrib * ((pow - 1) / (r / n)) : 0);
+  return future;
+}
 
 export default function CompoundClient() {
   const [principal, setPrincipal] = useState(10000);
@@ -10,51 +24,111 @@ export default function CompoundClient() {
   const [contrib, setContrib] = useState(0);
 
   const amount = useMemo(() => {
-    const P = principal;
-    const r = rate / 100;
-    const n = times;
-    const t = years;
-    const c = contrib;
-    const pow = Math.pow(1 + r / n, n * t);
-    const future = P * pow + (c > 0 ? c * ( (pow - 1) / (r / n) ) : 0);
-    return +future.toFixed(2);
+    return +compoundBalance(principal, rate, times, years, contrib).toFixed(2);
   }, [principal, rate, times, years, contrib]);
 
   const contributed = useMemo(() => principal + contrib * times * years, [principal, contrib, times, years]);
   const interest = useMemo(() => +(amount - contributed).toFixed(2), [amount, contributed]);
+
+  const growth = useMemo<GrowthPoint[]>(() => {
+    const points: GrowthPoint[] = [];
+    for (let y = 0; y <= years; y++) {
+      const balance = compoundBalance(principal, rate, times, y, contrib);
+      const contributions = principal + contrib * times * y;
+      points.push({ year: y, balance, contributions });
+    }
+    return points;
+  }, [principal, rate, times, years, contrib]);
+
+  const maxBalance = Math.max(...growth.map(g => g.balance), 1);
 
   return (
     <CalcShell
       title="Compound Interest Calculator"
       subtitle="Estimate investment growth with optional periodic contributions."
       result={
-        <>
-          <div className="kpi"><span>Future Value</span><span>${amount.toFixed(2)}</span></div>
-          <div style={{ height: 10 }} />
-          <div className="kpi"><span>Interest Earned</span><span>${interest.toFixed(2)}</span></div>
-        </>
+        <div className="compound-result">
+          <div className="compound-kpis">
+            <div className="compound-card">
+              <span className="label">Future value</span>
+              <strong>${amount.toFixed(2)}</strong>
+            </div>
+            <div className="compound-card">
+              <span className="label">Interest earned</span>
+              <strong>${interest.toFixed(2)}</strong>
+            </div>
+            <div className="compound-card">
+              <span className="label">Total contributions</span>
+              <strong>${contributed.toFixed(2)}</strong>
+            </div>
+          </div>
+          <svg className="compound-chart" viewBox="0 0 600 260" role="img" aria-label="Projected balance over time">
+            <defs>
+              <linearGradient id="growthLine" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stopColor="var(--accent)" />
+                <stop offset="100%" stopColor="var(--primary)" />
+              </linearGradient>
+            </defs>
+            <polyline
+              fill="none"
+              stroke="url(#growthLine)"
+              strokeWidth="4"
+              points={growth
+                .map(p => {
+                  const x = (p.year / Math.max(years, 1)) * 560 + 20;
+                  const y = 220 - (p.balance / maxBalance) * 200;
+                  return `${x},${y}`;
+                })
+                .join(' ')
+              }
+            />
+            <polyline
+              fill="none"
+              stroke="rgba(15,31,58,0.25)"
+              strokeWidth="2"
+              strokeDasharray="6 6"
+              points={growth
+                .map(p => {
+                  const x = (p.year / Math.max(years, 1)) * 560 + 20;
+                  const y = 220 - (p.contributions / maxBalance) * 200;
+                  return `${x},${y}`;
+                })
+                .join(' ')
+              }
+            />
+            <line x1="20" y1="220" x2="580" y2="220" stroke="rgba(15,31,58,0.2)" />
+            <line x1="20" y1="20" x2="20" y2="220" stroke="rgba(15,31,58,0.2)" />
+            <text x="580" y="240" textAnchor="end" fill="var(--muted)" fontSize="12">Years</text>
+            <text x="24" y="32" fill="var(--muted)" fontSize="12">Balance</text>
+          </svg>
+          <div className="compound-legend">
+            <span className="dot growth" /> Growth
+            <span className="dot contrib" /> Contributions
+          </div>
+          <p className="small">Solid line shows projected balance. Dashed line shows total contributions over time.</p>
+        </div>
       }
     >
       <div className="grid grid-2">
         <div>
           <label>Principal ($)</label>
-          <input className="input" type="number" value={principal} onChange={e => setPrincipal(+e.target.value)} />
+          <input className="input" type="number" value={principal} onChange={e => setPrincipal(Math.max(0, +e.target.value || 0))} />
         </div>
         <div>
           <label>Rate (% per year)</label>
-          <input className="input" type="number" step="0.01" value={rate} onChange={e => setRate(+e.target.value)} />
+          <input className="input" type="number" step="0.01" value={rate} onChange={e => setRate(Math.max(0, +e.target.value || 0))} />
         </div>
         <div>
           <label>Compounds / year</label>
-          <input className="input" type="number" value={times} onChange={e => setTimes(+e.target.value)} />
+          <input className="input" type="number" value={times} onChange={e => setTimes(Math.max(1, +e.target.value || 1))} />
         </div>
         <div>
           <label>Years</label>
-          <input className="input" type="number" value={years} onChange={e => setYears(+e.target.value)} />
+          <input className="input" type="number" value={years} onChange={e => setYears(Math.max(1, +e.target.value || 1))} />
         </div>
         <div style={{ gridColumn: '1 / -1' }}>
           <label>Contribution per period ($)</label>
-          <input className="input" type="number" value={contrib} onChange={e => setContrib(+e.target.value)} />
+          <input className="input" type="number" value={contrib} onChange={e => setContrib(Math.max(0, +e.target.value || 0))} />
         </div>
       </div>
     </CalcShell>

--- a/app/compound-interest/CompoundGuide.tsx
+++ b/app/compound-interest/CompoundGuide.tsx
@@ -19,6 +19,10 @@ export default function CompoundGuide() {
         Adding a fixed contribution each period accelerates growth and can significantly increase the
         future value of your investment.
       </p>
+      <p>
+        The calculator plots both the projected balance and cumulative contributions, making it easy
+        to see when compound interest begins to outpace the money you put in.
+      </p>
       <p className="small">
         Source:{' '}
         <a href="https://en.wikipedia.org/wiki/Compound_interest" target="_blank" rel="noopener">

--- a/app/compound-interest/page.tsx
+++ b/app/compound-interest/page.tsx
@@ -6,12 +6,12 @@ import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Compound Interest Calculator — Investment Growth Over Time',
-  description: 'Calculate compound interest with optional periodic contributions to see how savings grow.',
+  description: 'Calculate compound interest with optional periodic contributions and visual growth charts for your savings.',
   keywords: ['compound interest calculator','investment calculator','savings growth','future value','interest compounding'],
   alternates: { canonical: canonical('/compound-interest') },
   openGraph: {
     title: 'Compound Interest Calculator — Investment Growth Over Time',
-    description: 'Calculate compound interest with optional periodic contributions to see how savings grow.',
+    description: 'Calculate compound interest with optional periodic contributions and visual growth charts for your savings.',
     url: canonical('/compound-interest'),
     images: [
       {

--- a/app/compound-interest/styles.css
+++ b/app/compound-interest/styles.css
@@ -1,0 +1,64 @@
+.compound-result {
+  display: grid;
+  gap: 18px;
+}
+
+.compound-kpis {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.compound-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 12%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 22%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.compound-card .label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.compound-card strong {
+  font-size: 1.35rem;
+  color: var(--navy);
+}
+
+.compound-chart {
+  width: 100%;
+  background: color-mix(in oklab,var(--primary) 4%, var(--card));
+  border-radius: 20px;
+  border: 1px solid color-mix(in oklab,var(--primary) 18%, var(--border));
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.compound-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.compound-legend .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-flex;
+}
+
+.compound-legend .dot.growth {
+  background: var(--accent);
+}
+
+.compound-legend .dot.contrib {
+  background: rgba(15,31,58,0.35);
+}

--- a/app/date-diff/DateDiffClient.tsx
+++ b/app/date-diff/DateDiffClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { useMemo, useState } from "react";
-import CalcShell from "../components/CalcShell";
 import { differenceInDays } from "@/lib/dates";
+import { differenceInMonths, differenceInYears } from "date-fns";
+import CalcShell from "../components/CalcShell";
+import "./styles.css";
 
 export default function DateDiffClient(){
   const today = new Date().toISOString().slice(0,10);
@@ -11,21 +13,70 @@ export default function DateDiffClient(){
   const res = useMemo(()=>{
     const s = new Date(start); const e = new Date(end);
     if (isNaN(+s) || isNaN(+e)) return null;
-    const days = differenceInDays(e, s);
-    const weeks = +(days / 7).toFixed(2);
-    return { days, weeks };
+    const asc = s <= e ? { s, e } : { s: e, e: s };
+    const days = differenceInDays(asc.e, asc.s);
+    const weeks = +((days) / 7).toFixed(2);
+    const months = differenceInMonths(asc.e, asc.s);
+    const years = differenceInYears(asc.e, asc.s);
+    const hours = days * 24;
+    const minutes = hours * 60;
+    return { days, weeks, months, years, hours, minutes, order: asc };
   }, [start, end]);
 
+  const timelinePercent = useMemo(() => {
+    if (!res || res.days === 0) return 0;
+    const capped = Math.min(res.days, 365);
+    return capped / 365;
+  }, [res]);
+
   return (
-    <CalcShell title="Date Difference" subtitle="Days and weeks between two dates." result={
-      res ? (<>
-        <div className="kpi"><span>Total days</span><span>{res.days}</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Total weeks</span><span>{res.weeks}</span></div>
-      </>) : (<div className="kpi"><span>Total days</span><span>—</span></div>)
+    <CalcShell title="Date Difference" subtitle="Days, weeks and timeline insight between two dates." result={
+      res ? (
+        <div className="date-result">
+          <div className="date-cards">
+            <div className="date-card">
+              <span className="label">Total days</span>
+              <strong>{res.days}</strong>
+            </div>
+            <div className="date-card">
+              <span className="label">Weeks</span>
+              <strong>{res.weeks}</strong>
+            </div>
+            <div className="date-card">
+              <span className="label">Months</span>
+              <strong>{res.months}</strong>
+            </div>
+          </div>
+          <div className="date-timeline">
+            <span className="stamp">{res.order.s.toLocaleDateString()}</span>
+            <div className="track">
+              <div className="fill" style={{ width: `${timelinePercent * 100}%` }} />
+              <span className="days">{res.days} days</span>
+            </div>
+            <span className="stamp">{res.order.e.toLocaleDateString()}</span>
+          </div>
+          <div className="date-grid">
+            <div>
+              <span className="label">Years</span>
+              <strong>{res.years}</strong>
+            </div>
+            <div>
+              <span className="label">Hours</span>
+              <strong>{res.hours.toLocaleString()}</strong>
+            </div>
+            <div>
+              <span className="label">Minutes</span>
+              <strong>{res.minutes.toLocaleString()}</strong>
+            </div>
+          </div>
+          <p className="small">Bar highlights up to one calendar year for quick comparisons.</p>
+        </div>
+      ) : (
+        <div className="kpi"><span>Total days</span><span>—</span></div>
+      )
     }>
       <div className="grid grid-2">
-        <div><label>Start date</label><input className="input" type="date" value={start} onChange={e=>setStart(e.target.value)} /></div>
+        <div><label>Start date</label><input className="input" type="date" value={start} onChange={e=>setStart(e.target.value)}/></div>
         <div><label>End date</label><input className="input" type="date" value={end} onChange={e=>setEnd(e.target.value)} /></div>
       </div>
     </CalcShell>

--- a/app/date-diff/DateDiffGuide.tsx
+++ b/app/date-diff/DateDiffGuide.tsx
@@ -13,6 +13,11 @@ export default function DateDiffGuide() {
         Count the number of days between the dates and divide as needed: 7 days per week and
         365 days per year (taking leap years into account).
       </p>
+      <p>
+        The gradient bar in the calculator highlights how much of a single calendar year the span
+        represents. Longer periods cap at one year so you can instantly compare shorter and longer
+        ranges visually.
+      </p>
       <h3 style={{ marginTop: 24 }}>Why it matters</h3>
       <p>
         Knowing exact gaps between dates is useful for project planning, age tracking and

--- a/app/date-diff/metadata.ts
+++ b/app/date-diff/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'Date Difference Calculator — Days Between Dates',
-  description: 'Calculate days and weeks between two dates instantly.',
-  keywords: ['date difference', 'days between dates', 'date calculator', 'duration calculator'],
+  title: 'Date Difference Calculator — Timeline & Duration Breakdown',
+  description: 'Calculate days, weeks, months and view a visual timeline between any two dates.',
+  keywords: ['date difference', 'days between dates', 'duration calculator', 'date timeline'],
   alternates: { canonical: canonical('/date-diff') },
   openGraph: {
-    title: 'Date Difference Calculator — Days Between Dates',
-    description: 'Calculate days and weeks between two dates instantly.',
+    title: 'Date Difference Calculator — Timeline & Duration Breakdown',
+    description: 'Calculate days, weeks, months and view a visual timeline between any two dates.',
     url: canonical('/date-diff'),
-    images: [{ url: '/images/date.jpg', width: 1200, height: 630, alt: 'Date difference calculator' }]
+    images: [{ url: '/images/date.jpg', width: 1200, height: 630, alt: 'Date difference calculator timeline' }]
   }
 };

--- a/app/date-diff/styles.css
+++ b/app/date-diff/styles.css
@@ -1,0 +1,78 @@
+.date-result {
+  display: grid;
+  gap: 18px;
+}
+
+.date-cards {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+}
+
+.date-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 12%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 20%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.date-card .label,
+.date-grid .label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.date-card strong,
+.date-grid strong {
+  font-size: 1.3rem;
+  color: var(--navy);
+}
+
+.date-timeline {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.date-timeline .track {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(15,31,58,0.12);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--navy);
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.date-timeline .fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+  opacity: 0.8;
+}
+
+.date-timeline .days {
+  position: relative;
+  z-index: 1;
+}
+
+.date-timeline .stamp {
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.date-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}

--- a/app/loan/LoanClient.tsx
+++ b/app/loan/LoanClient.tsx
@@ -2,30 +2,116 @@
 import { useMemo, useState } from "react";
 import CalcShell from "../components/CalcShell";
 import { amortizedPayment } from "@/lib/finance";
+import "./styles.css";
+
+interface ScheduleRow {
+  month: number;
+  principal: number;
+  interest: number;
+  balance: number;
+}
+
+const RADIUS = 80;
+const RING_CIRC = 2 * Math.PI * RADIUS;
+
+function buildSchedule(amount: number, rate: number, months: number): ScheduleRow[] {
+  if (months <= 0) return [];
+  const payment = amortizedPayment(amount, rate, months);
+  const monthlyRate = rate / 100 / 12;
+  let balance = amount;
+  const rows: ScheduleRow[] = [];
+  for (let i = 1; i <= Math.min(months, 12); i++) {
+    const interest = monthlyRate === 0 ? 0 : balance * monthlyRate;
+    const principal = payment - interest;
+    balance = Math.max(0, balance - principal);
+    rows.push({ month: i, principal, interest, balance });
+  }
+  return rows;
+}
 
 export default function LoanClient(){
   const [amount, setAmount] = useState(15000);
   const [rate, setRate] = useState(7.9);
   const [months, setMonths] = useState(48);
 
-  const m = useMemo(()=> amortizedPayment(amount, rate, months), [amount, rate, months]);
-  const total = useMemo(()=> m * months, [m, months]);
+  const payment = useMemo(()=> amortizedPayment(amount, rate, months), [amount, rate, months]);
+  const total = useMemo(()=> payment * months, [payment, months]);
   const interest = useMemo(()=> total - amount, [total, amount]);
 
+  const schedule = useMemo(() => buildSchedule(amount, rate, months), [amount, rate, months]);
+  const interestShare = total > 0 ? interest / total : 0;
+
   return (
-    <CalcShell title="Loan Calculator" subtitle="Payments and totals for personal/auto loans." result={
-      <>
-        <div className="kpi"><span>Monthly</span><span>€{Math.round(m).toLocaleString()}</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Total interest</span><span>€{Math.round(interest).toLocaleString()}</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Total paid</span><span>€{Math.round(total).toLocaleString()}</span></div>
-      </>
+    <CalcShell title="Loan Calculator" subtitle="Payments, totals and your first year amortisation at a glance." result={
+      <div className="loan-result">
+        <div className="loan-kpis">
+          <div className="loan-card">
+            <span className="label">Monthly</span>
+            <strong>€{Math.round(payment).toLocaleString()}</strong>
+          </div>
+          <div className="loan-card">
+            <span className="label">Total interest</span>
+            <strong>€{Math.round(interest).toLocaleString()}</strong>
+          </div>
+          <div className="loan-card">
+            <span className="label">Total paid</span>
+            <strong>€{Math.round(total).toLocaleString()}</strong>
+          </div>
+        </div>
+        <div className="loan-ring" aria-hidden="true">
+          <svg width="200" height="200" viewBox="0 0 200 200">
+            <circle cx="100" cy="100" r={RADIUS} stroke="rgba(15,31,58,0.1)" strokeWidth="24" fill="none" />
+            <circle
+              cx="100"
+              cy="100"
+              r={RADIUS}
+              stroke="url(#loanGradient)"
+              strokeWidth="24"
+              strokeDasharray={`${interestShare * RING_CIRC} ${(1-interestShare) * RING_CIRC}`}
+              strokeLinecap="round"
+              fill="none"
+              transform="rotate(-90 100 100)"
+            />
+            <defs>
+              <linearGradient id="loanGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="var(--accent)" />
+                <stop offset="100%" stopColor="var(--primary)" />
+              </linearGradient>
+            </defs>
+            <text x="100" y="92" textAnchor="middle" fontSize="18" fontWeight="700" fill="var(--navy)">
+              {Math.round(interestShare * 100)}%
+            </text>
+            <text x="100" y="112" textAnchor="middle" fontSize="12" fill="var(--muted)">
+              interest share
+            </text>
+          </svg>
+        </div>
+        {schedule.length > 0 && (
+          <div className="loan-bars">
+            {schedule.map(row => {
+              const totalBar = row.principal + row.interest;
+              const principalWidth = totalBar > 0 ? (row.principal / totalBar) * 100 : 0;
+              const interestWidth = totalBar > 0 ? (row.interest / totalBar) * 100 : 0;
+              return (
+                <div key={row.month} className="bar-row">
+                  <span>Month {row.month}</span>
+                  <div className="bar">
+                    <div className="principal" style={{ width: `${principalWidth}%` }} />
+                    <div className="interest" style={{ width: `${interestWidth}%` }} />
+                  </div>
+                  <span>€{Math.round(row.balance).toLocaleString()}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <p className="small">Bars show principal vs interest for your first 12 payments. Balance is updated after each payment.</p>
+      </div>
     }>
       <div className="grid grid-2">
-        <div><label>Loan amount (€)</label><input className="input" type="number" value={amount} onChange={e=>setAmount(+e.target.value)} /></div>
-        <div><label>Interest rate (% p.a.)</label><input className="input" type="number" step="0.01" value={rate} onChange={e=>setRate(+e.target.value)} /></div>
-        <div><label>Term (months)</label><input className="input" type="number" min={1} step={1} value={months} onChange={e=>setMonths(+e.target.value)} /></div>
+        <div><label>Loan amount (€)</label><input className="input" type="number" value={amount} onChange={e=>setAmount(Math.max(0, +e.target.value || 0))} /></div>
+        <div><label>Interest rate (% p.a.)</label><input className="input" type="number" step="0.01" value={rate} onChange={e=>setRate(Math.max(0, +e.target.value || 0))} /></div>
+        <div><label>Term (months)</label><input className="input" type="number" min={1} step={1} value={months} onChange={e=>setMonths(Math.max(1, +e.target.value || 1))} /></div>
       </div>
     </CalcShell>
   );

--- a/app/loan/LoanGuide.tsx
+++ b/app/loan/LoanGuide.tsx
@@ -18,6 +18,10 @@ export default function LoanGuide() {
         Understanding amortization helps you compare loans and budget effectively by showing how much
         interest you’ll pay over the life of the loan.
       </p>
+      <p>
+        The visual bars in the calculator highlight the principal and interest mix for the first
+        year so you can see how quickly the balance starts to fall.
+      </p>
       <p className="small">
         Source:{' '}
         <a

--- a/app/loan/metadata.ts
+++ b/app/loan/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'Loan Calculator — Payment Schedule & Interest',
-  description: 'Plan your personal or auto loan with monthly payment, total interest and payoff estimates.',
-  keywords: ['loan calculator', 'monthly payment', 'interest calculator', 'personal loan', 'auto loan'],
+  title: 'Loan Calculator — Interactive Amortisation & Interest Share',
+  description: 'Plan your personal or auto loan with monthly payments, interest share ring and first-year amortisation bars.',
+  keywords: ['loan calculator', 'monthly payment', 'interest share', 'amortisation schedule', 'personal loan'],
   alternates: { canonical: canonical('/loan') },
   openGraph: {
-    title: 'Loan Calculator — Payment Schedule & Interest',
-    description: 'Plan your personal or auto loan with monthly payment, total interest and payoff estimates.',
+    title: 'Loan Calculator — Interactive Amortisation & Interest Share',
+    description: 'Plan your personal or auto loan with monthly payments, interest share ring and first-year amortisation bars.',
     url: canonical('/loan'),
-    images: [{ url: '/images/loan.jpg', width: 1200, height: 630, alt: 'Loan calculator' }]
+    images: [{ url: '/images/loan.jpg', width: 1200, height: 630, alt: 'Loan calculator amortisation' }]
   }
 };

--- a/app/loan/styles.css
+++ b/app/loan/styles.css
@@ -1,0 +1,68 @@
+.loan-result {
+  display: grid;
+  gap: 18px;
+}
+
+.loan-kpis {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.loan-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 12%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 22%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.loan-card .label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.loan-card strong {
+  font-size: 1.4rem;
+  color: var(--navy);
+}
+
+.loan-ring {
+  display: flex;
+  justify-content: center;
+}
+
+.loan-bars {
+  display: grid;
+  gap: 10px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.bar {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  border-radius: 999px;
+  height: 12px;
+  background: rgba(15,31,58,0.08);
+}
+
+.bar .principal {
+  background: #22c55e;
+}
+
+.bar .interest {
+  background: var(--accent);
+}

--- a/app/mortgage/page.tsx
+++ b/app/mortgage/page.tsx
@@ -6,12 +6,12 @@ import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
   title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
-  description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees, upfront costs and a comprehensive mortgage FAQ.',
+  description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with visual monthly breakdowns, taxes, insurance, fees and upfront costs.',
   keywords: ['mortgage calculator', 'home loan', 'amortization', 'down payment', 'property tax', 'home insurance', 'HOA fees', 'strata fees', 'body corporate fees', 'condo fees', 'ground rent', 'stamp duty', 'CMHC insurance', 'LMI', 'notary fees', 'processing fee', 'mortgage faq', 'home loan faq', 'mortgage questions', 'US', 'Canada', 'UK', 'Australia', 'India', 'Europe'],
   alternates: { canonical: canonical('/mortgage') },
   openGraph: {
     title: 'Mortgage Calculator — Country-Specific Home Loan Estimates',
-    description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with taxes, insurance, fees, upfront costs and a comprehensive mortgage FAQ.',
+    description: 'Country-aware mortgage calculator for the US, Canada, UK, Australia, Europe and India with visual monthly breakdowns, taxes, insurance, fees and upfront costs.',
     url: canonical('/mortgage'),
     images: [{ url: '/images/mortgage.jpg', width: 1200, height: 630, alt: 'Mortgage calculator' }]
   }

--- a/app/mortgage/styles.css
+++ b/app/mortgage/styles.css
@@ -1,0 +1,95 @@
+.mortgage-result {
+  display: grid;
+  gap: 18px;
+}
+
+.mortgage-kpis {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.mortgage-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 12%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 22%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mortgage-card .label,
+.mortgage-upfront .label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.mortgage-card strong,
+.mortgage-upfront strong {
+  font-size: 1.35rem;
+  color: var(--navy);
+}
+
+.mortgage-breakdown {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+}
+
+.mortgage-legend {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.mortgage-legend div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mortgage-legend dt {
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.mortgage-legend dd {
+  margin: 0 0 0 auto;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-flex;
+}
+
+.dot.principal {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.dot.extras {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: color-mix(in oklab,var(--primary) 60%, var(--accent));
+}
+
+.mortgage-upfront {
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklab,var(--primary) 6%, var(--card));
+  border: 1px solid color-mix(in oklab,var(--primary) 18%, var(--border));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}

--- a/app/tip/TipClient.tsx
+++ b/app/tip/TipClient.tsx
@@ -1,6 +1,18 @@
 "use client";
 import { useMemo, useState } from "react";
 import CalcShell from "../components/CalcShell";
+import "./styles.css";
+
+const SIZE = 180;
+const STROKE = 18;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRC = 2 * Math.PI * RADIUS;
+
+function createDash(percent: number) {
+  const clamped = Math.min(1, Math.max(0, percent));
+  const filled = CIRC * clamped;
+  return `${filled} ${CIRC - filled}`;
+}
 
 export default function TipClient(){
   const [bill, setBill] = useState(80);
@@ -10,21 +22,63 @@ export default function TipClient(){
   const tipAmt = useMemo(()=> +(bill * tip / 100).toFixed(2), [bill, tip]);
   const total = useMemo(()=> +(bill + tipAmt).toFixed(2), [bill, tipAmt]);
   const per = useMemo(()=> people > 0 ? +(total / people).toFixed(2) : 0, [total, people]);
+  const perTip = useMemo(()=> people > 0 ? +(tipAmt / people).toFixed(2) : 0, [tipAmt, people]);
+  const basePer = useMemo(()=> people > 0 ? +((bill) / people).toFixed(2) : 0, [bill, people]);
+
+  const tipShare = total > 0 ? tipAmt / total : 0;
 
   return (
-    <CalcShell title="Tip Calculator" subtitle="Split the bill and tips quickly." result={
-      <>
-        <div className="kpi"><span>Tip</span><span>€{tipAmt.toFixed(2)}</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Total</span><span>€{total.toFixed(2)}</span></div>
-        <div style={{height:10}}/>
-        <div className="kpi"><span>Per person</span><span>€{per.toFixed(2)}</span></div>
-      </>
+    <CalcShell title="Tip Calculator" subtitle="Split the bill and tips quickly with a visual share dial." result={
+      <div className="tip-result">
+        <div className="tip-visual" aria-hidden="true">
+          <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} role="presentation">
+            <defs>
+              <linearGradient id="tipGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="var(--accent)" />
+                <stop offset="100%" stopColor="var(--primary)" />
+              </linearGradient>
+            </defs>
+            <circle cx={SIZE/2} cy={SIZE/2} r={RADIUS} stroke="rgba(15,31,58,0.1)" strokeWidth={STROKE} fill="none" />
+            <circle
+              cx={SIZE/2}
+              cy={SIZE/2}
+              r={RADIUS}
+              stroke="url(#tipGradient)"
+              strokeWidth={STROKE}
+              strokeDasharray={createDash(tipShare)}
+              strokeLinecap="round"
+              fill="none"
+              transform={`rotate(-90 ${SIZE/2} ${SIZE/2})`}
+            />
+            <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="24" fontWeight="700" fill="var(--navy)">
+              {(tipShare * 100).toFixed(1)}%
+            </text>
+            <text x="50%" y="50%" dominantBaseline="hanging" textAnchor="middle" dy="18" fontSize="12" fill="var(--muted)">
+              tip share
+            </text>
+          </svg>
+        </div>
+        <div className="tip-metrics">
+          <div className="tip-card">
+            <span className="label">Tip</span>
+            <strong>€{tipAmt.toFixed(2)}</strong>
+          </div>
+          <div className="tip-card">
+            <span className="label">Total</span>
+            <strong>€{total.toFixed(2)}</strong>
+          </div>
+          <div className="tip-card">
+            <span className="label">Per person</span>
+            <strong>€{per.toFixed(2)}</strong>
+            <span className="sub">€{basePer.toFixed(2)} food / €{perTip.toFixed(2)} tip</span>
+          </div>
+        </div>
+      </div>
     }>
       <div className="grid grid-2">
-        <div><label>Bill (€)</label><input className="input" type="number" step="0.01" value={bill} onChange={e=>setBill(+e.target.value)} /></div>
-        <div><label>Tip (%)</label><input className="input" type="number" step="0.1" value={tip} onChange={e=>setTip(+e.target.value)} /></div>
-        <div><label>People</label><input className="input" type="number" min={1} step={1} value={people} onChange={e=>setPeople(+e.target.value)} /></div>
+        <div><label>Bill (€)</label><input className="input" type="number" step="0.01" value={bill} onChange={e=>setBill(Math.max(0, +e.target.value || 0))} /></div>
+        <div><label>Tip (%)</label><input className="input" type="number" step="0.1" value={tip} onChange={e=>setTip(Math.max(0, +e.target.value || 0))} /></div>
+        <div><label>People</label><input className="input" type="number" min={1} step={1} value={people} onChange={e=>setPeople(Math.max(1, +e.target.value || 1))} /></div>
       </div>
     </CalcShell>
   );

--- a/app/tip/TipGuide.tsx
+++ b/app/tip/TipGuide.tsx
@@ -13,6 +13,11 @@ export default function TipGuide() {
         <code>{"Tip = bill \u00d7 (percentage / 100)"}</code>. The total per person is the bill plus
         tip divided by the number of people.
       </p>
+      <p>
+        The circular share dial in the calculator visualises how much of the final bill is tip.
+        Adjusting the percentage updates the dial instantly so you can see whether you are tipping
+        below or above common norms.
+      </p>
       <h3 style={{ marginTop: 24 }}>Why it matters</h3>
       <p>
         Quickly calculating fair tips helps avoid awkward math at the table and ensures staff

--- a/app/tip/metadata.ts
+++ b/app/tip/metadata.ts
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import { canonical } from '@/lib/seo';
 
 export const metadata: Metadata = {
-  title: 'Tip Calculator — Split Bills & Tips',
-  description: 'Quickly split restaurant bills and tips per person with adjustable percentages.',
-  keywords: ['tip calculator', 'bill splitter', 'restaurant tip', 'split bill', 'gratuity'],
+  title: 'Tip Calculator — Visual Bill Splitter',
+  description: 'Quickly split restaurant bills, see tip share percentages and cost per person with adjustable percentages.',
+  keywords: ['tip calculator', 'bill splitter', 'restaurant tip', 'split bill', 'tip percentage'],
   alternates: { canonical: canonical('/tip') },
   openGraph: {
-    title: 'Tip Calculator — Split Bills & Tips',
-    description: 'Quickly split restaurant bills and tips per person with adjustable percentages.',
+    title: 'Tip Calculator — Visual Bill Splitter',
+    description: 'Quickly split restaurant bills, see tip share percentages and cost per person with adjustable percentages.',
     url: canonical('/tip'),
-    images: [{ url: '/images/tips.jpg', width: 1200, height: 630, alt: 'Tip calculator' }]
+    images: [{ url: '/images/tips.jpg', width: 1200, height: 630, alt: 'Tip calculator share dial' }]
   }
 };

--- a/app/tip/styles.css
+++ b/app/tip/styles.css
@@ -1,0 +1,48 @@
+.tip-result {
+  display: grid;
+  gap: 16px;
+  align-items: center;
+  grid-template-columns: minmax(180px, 220px) 1fr;
+}
+
+.tip-visual {
+  justify-self: center;
+}
+
+.tip-metrics {
+  display: grid;
+  gap: 12px;
+}
+
+.tip-card {
+  border-radius: 14px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in oklab,var(--primary) 18%, var(--border));
+  background: color-mix(in oklab,var(--primary) 10%, var(--card));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tip-card .label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tip-card strong {
+  font-size: 1.4rem;
+  color: var(--navy);
+}
+
+.tip-card .sub {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .tip-result {
+    grid-template-columns: 1fr;
+  }
+}

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -1,2 +1,2 @@
-import { differenceInDays, addMonths } from "date-fns";
-export { differenceInDays, addMonths };
+import { differenceInDays, differenceInWeeks, addMonths } from "date-fns";
+export { differenceInDays, differenceInWeeks, addMonths };


### PR DESCRIPTION
## Summary
- overhaul every calculator layout with bespoke visualisations, including age countdown dials, BMI range bars, business-day breakdowns and amortisation charts
- add supporting styling and helper components for the new dashboards plus richer explanatory copy and updated SEO metadata
- extend the business-days API response so the UI can display weekend and holiday breakdowns alongside total workdays

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1454f01dc8329acd7997124565f77